### PR TITLE
feat(EventBriefDTO, EventListDTO, TimeDTO, EventListRequestDTO, TalkCalendarService, TalkCalendarController): 톡캘린더 일정 목록 조회 구현

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
@@ -1,0 +1,60 @@
+package org.cookieandkakao.babting.domain.calendar.controller;
+
+import java.util.Collections;
+import org.cookieandkakao.babting.domain.calendar.dto.EventListDTO;
+import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/calendar")
+public class TalkCalendarController {
+
+    private final TalkCalendarService talkCalendarService;
+
+    public TalkCalendarController(TalkCalendarService talkCalendarService) {
+        this.talkCalendarService = talkCalendarService;
+    }
+
+    @GetMapping("/events")
+    public ResponseEntity<EventListDTO> getEventList(
+        @RequestHeader(value = "Authorization") String authorizationHeader,
+        @RequestParam(value = "from") String from,
+        @RequestParam(value = "to") String to
+    ) {
+        String accessToken = authorizationHeader.replace("Bearer ", "");
+        try {
+            EventListDTO eventList = talkCalendarService.getEventList(accessToken, from, to);
+
+            HttpStatus status = HttpStatus.OK;
+            String message = "일정 목록을 조회했습니다.";
+
+            if (eventList.events().isEmpty()) {
+                status = HttpStatus.NO_CONTENT;
+                message = "조회된 일정이 없습니다.";
+            }
+
+            EventListDTO responseBody = new EventListDTO(
+                status.value(),
+                message,
+                eventList.events(),
+                eventList.hasNext()
+            );
+
+            return ResponseEntity.status(status).body(responseBody);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new EventListDTO(
+                    500,
+                    "일정 조회 중 오류가 발생했습니다.",
+                    Collections.emptyList(),
+                    false
+                ));
+        }
+    }
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
@@ -2,13 +2,14 @@ package org.cookieandkakao.babting.domain.calendar.controller;
 
 import java.util.Collections;
 import org.cookieandkakao.babting.domain.calendar.dto.EventListDTO;
+import org.cookieandkakao.babting.domain.calendar.dto.EventListRequestDTO;
 import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,11 +25,13 @@ public class TalkCalendarController {
     @GetMapping("/events")
     public ResponseEntity<EventListDTO> getEventList(
         @RequestHeader(value = "Authorization") String authorizationHeader,
-        @RequestParam(value = "from") String from,
-        @RequestParam(value = "to") String to
+        @RequestBody EventListRequestDTO eventListRequestDTO
     ) {
         String accessToken = authorizationHeader.replace("Bearer ", "");
         try {
+            String from = eventListRequestDTO.from();
+            String to = eventListRequestDTO.to();
+
             EventListDTO eventList = talkCalendarService.getEventList(accessToken, from, to);
 
             HttpStatus status = HttpStatus.OK;

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventBriefDTO.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventBriefDTO.java
@@ -1,31 +1,25 @@
 package org.cookieandkakao.babting.domain.calendar.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record EventBriefDTO(
 
-    @JsonProperty("id")
     String id,
 
-    @JsonProperty("title")
     String title,
 
-    @JsonProperty("type")
     String type,
 
-    @JsonProperty("calendar_id")
     String calendarId,
 
-    @JsonProperty("time")
     TimeDTO time,
 
-    @JsonProperty("is_host")
     boolean isHost,
 
-    @JsonProperty("is_recur_event")
     boolean isRecurEvent,
 
-    @JsonProperty("color")
     String color
 ) {
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventBriefDTO.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventBriefDTO.java
@@ -1,0 +1,32 @@
+package org.cookieandkakao.babting.domain.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record EventBriefDTO(
+
+    @JsonProperty("id")
+    String id,
+
+    @JsonProperty("title")
+    String title,
+
+    @JsonProperty("type")
+    String type,
+
+    @JsonProperty("calendar_id")
+    String calendarId,
+
+    @JsonProperty("time")
+    TimeDTO time,
+
+    @JsonProperty("is_host")
+    boolean isHost,
+
+    @JsonProperty("is_recur_event")
+    boolean isRecurEvent,
+
+    @JsonProperty("color")
+    String color
+) {
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventListDTO.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventListDTO.java
@@ -1,0 +1,18 @@
+package org.cookieandkakao.babting.domain.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record EventListDTO(
+
+    int status,
+
+    String message,
+
+    List<EventBriefDTO> events,
+
+    @JsonProperty("has_next")
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventListRequestDTO.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/EventListRequestDTO.java
@@ -1,0 +1,10 @@
+package org.cookieandkakao.babting.domain.calendar.dto;
+
+public record EventListRequestDTO(
+
+    String from,
+
+    String to
+) {
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/TimeDTO.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/TimeDTO.java
@@ -1,19 +1,17 @@
 package org.cookieandkakao.babting.domain.calendar.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record TimeDTO(
 
-    @JsonProperty("start_at")
     String startAt,
 
-    @JsonProperty("end_at")
     String endAt,
 
-    @JsonProperty("time_zone")
     String timeZone,
 
-    @JsonProperty("all_day")
     boolean allDay
 ) {
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/TimeDTO.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/TimeDTO.java
@@ -1,0 +1,20 @@
+package org.cookieandkakao.babting.domain.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TimeDTO(
+
+    @JsonProperty("start_at")
+    String startAt,
+
+    @JsonProperty("end_at")
+    String endAt,
+
+    @JsonProperty("time_zone")
+    String timeZone,
+
+    @JsonProperty("all_day")
+    boolean allDay
+) {
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/entity/Event.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/entity/Event.java
@@ -28,7 +28,7 @@ public class Event {
     @JoinColumn(name = "time_id", nullable = false)
     private Time time;
 
-    @Column(nullable = false)
+    @Column
     private String title;
 
     @Column

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/entity/Event.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/entity/Event.java
@@ -28,13 +28,13 @@ public class Event {
     @JoinColumn(name = "time_id", nullable = false)
     private Time time;
 
-    @Column
+    @Column(nullable = false)
     private String title;
 
     @Column
     private String type;
 
-    @Column
+    @Column(nullable = false)
     private boolean repeatedSchedule;
 
     @Column

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
@@ -12,8 +12,6 @@ public class TalkCalendarService {
 
     private final RestClient restClient = RestClient.builder().build();
 
-    public TalkCalendarService() {}
-
     public EventListDTO getEventList(String accessToken, String from, String to) {
         String url = "https://kapi.kakao.com/v2/api/calendar/events";
         URI uri = buildUri(url, from, to);

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
@@ -1,0 +1,35 @@
+package org.cookieandkakao.babting.domain.calendar.service;
+
+import java.net.URI;
+import org.cookieandkakao.babting.domain.calendar.dto.EventListDTO;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class TalkCalendarService {
+
+    private final RestClient restClient = RestClient.builder().build();
+
+    public TalkCalendarService() {}
+
+    public EventListDTO getEventList(String accessToken, String from, String to) {
+        String url = "https://kapi.kakao.com/v2/api/calendar/events";
+        URI uri = buildUri(url, from, to);
+        try {
+            ResponseEntity<EventListDTO> response = restClient.get()
+                .uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .toEntity(EventListDTO.class);
+            return response.getBody();
+        } catch (Exception e) {
+            throw new RuntimeException("API 호출 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+
+    private URI buildUri(String baseUrl, String from, String to) {
+        return URI.create(String.format("%s?from=%s&to=%s&limit=100&time_zone=Asia/Seoul", baseUrl, from, to));
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
톡캘린더의 일정 목록을 조회할 수 있는 기능을 구현했습니다. 그걸 위한 DTO, Service, Controller를 만들었습니다. event의 title은 null로 변경했습니다. null로 한 이유는 저희 서비스에서 만든 일정이 아닐 경우 time을 제외한 다른 값들(title 포함)은 못 받아오기 때문입니다.

## 리뷰어에게...
TalkCalendarService의 톡캘린더 REST API의 URL은 추후 KakaoProperties가 추가되면 수정하겠습니다! 테스트하기 위해서는 accessToken이 필요합니다. step2 때 사용했던 로그인 방식으로 accessToken을 얻어와 테스트 했을 때는 작성한 API 명세서에 맞게 값이 출력되는 것을 확인했습니다. 코드를 봤을 때 이름을 변경해야 하거나, 중복이 있는 것 같다, 중복을 줄일 수 있을 것 같다고 생각이 드는 부분이 있으면 말씀해주시면 좋겠습니다!

## 관련 이슈

closes #11 

## 체크리스트

- [X] `reviewers` 설정
- [X] `label` 설정
