### PR TITLE
[FEAT] 회원 본인 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package org.cookieandkakao.babting.domain.member.controller;
+
+import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
+import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody;
+import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
+import org.cookieandkakao.babting.domain.member.dto.MemberProfileGetResponse;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponseBody.SuccessBody<MemberProfileGetResponse>> getMemberProfile(
+        @LoginMemberId Long memberId) {
+        MemberProfileGetResponse memberProfile = memberService.getMemberProfile(memberId);
+        return ApiResponseGenerator.success(HttpStatus.OK, "프로필 조회 성공", memberProfile);
+    }
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/member/dto/MemberProfileGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/dto/MemberProfileGetResponse.java
@@ -1,0 +1,8 @@
+package org.cookieandkakao.babting.domain.member.dto;
+
+public record MemberProfileGetResponse(
+        Long memberId,
+        String nickname,
+        String thumbnailImageUrl,
+        String profileImageUrl
+) { }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
@@ -1,0 +1,29 @@
+package org.cookieandkakao.babting.domain.member.service;
+
+import org.cookieandkakao.babting.domain.member.dto.MemberProfileGetResponse;
+import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.cookieandkakao.babting.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public MemberProfileGetResponse getMemberProfile(Long memberId) {
+        Member member = findMember(memberId);
+        return new MemberProfileGetResponse(memberId, member.getNickname(), member.getThumbnailImageUrl(),
+            member.getProfileImageUrl());
+    }
+
+    public Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new NoSuchElementException("해당 사용자가 존재하지 않습니다."));
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
회원 본인 프로필 조회 기능 구현

## 리뷰어에게...
인증이 아닌 회원 관련 기능을 위한 MemberController와 MemberService를 추가했습니다.
memberId로 Member Entity를 찾아올 수 있도록 MemberService에 findMember라는 메서드를 추가했습니다.

## 관련 이슈

closes #

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
