### PR TITLE
[FEAT] 모임 기능 구현

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodGetResponse.java
@@ -1,8 +1,13 @@
 package org.cookieandkakao.babting.domain.food.dto;
 
+import org.cookieandkakao.babting.domain.food.entity.Food;
+
 public record FoodGetResponse(
         Long foodId,
         String category,
         String name
 ) {
+    public static FoodGetResponse from(Food food){
+        return new FoodGetResponse(food.getFoodId(), food.getFoodCategory().getName(), food.getName());
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,7 +36,7 @@ public class MeetingController {
     @PostMapping
     public ResponseEntity<SuccessBody<Void>> createMeeting(
         @LoginMemberId Long memberId,
-        MeetingCreateRequest meetingCreateRequest){
+        @RequestBody MeetingCreateRequest meetingCreateRequest){
         meetingService.createMeeting(memberId, meetingCreateRequest);
         return ApiResponseGenerator.success(HttpStatus.CREATED, "모임 생성 성공");
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -3,7 +3,7 @@ package org.cookieandkakao.babting.domain.meeting.controller;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.SuccessBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
 import org.cookieandkakao.babting.domain.food.service.FoodService;
-import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmDateTimeGetRequest;
+import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.service.MeetingService;
 import org.cookieandkakao.babting.domain.member.entity.Member;
@@ -50,9 +50,10 @@ public class MeetingController {
     public ResponseEntity<SuccessBody<Void>> decideMeeting(
         @PathVariable("meetingId") Long meetingId,
         Member member,
-        ConfirmDateTimeGetRequest confirmDateTimeGetRequest
+        ConfirmMeetingGetRequest confirmMeetingGetRequest
     ){
-        meetingService.decideMeetingTime(member, confirmDateTimeGetRequest.confirmDateTime(), meetingId);
+        meetingService.decideMeeting(member, confirmMeetingGetRequest.confirmFoodId(),
+            confirmMeetingGetRequest.confirmDateTime(), meetingId);
         return ApiResponseGenerator.success(HttpStatus.OK, "모임 시간 확정 성공");
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.meeting.controller;
 
+import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.SuccessBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
 import org.cookieandkakao.babting.domain.food.service.FoodService;
@@ -29,9 +30,9 @@ public class MeetingController {
     // 모임 생성(주최자)
     @PostMapping
     public ResponseEntity<SuccessBody<Void>> createMeeting(
-        Member member,
+        @LoginMemberId Long memberId,
         MeetingCreateRequest meetingCreateRequest){
-        meetingService.createMeeting(member, meetingCreateRequest);
+        meetingService.createMeeting(memberId, meetingCreateRequest);
         return ApiResponseGenerator.success(HttpStatus.CREATED, "모임 생성 성공");
     }
 
@@ -39,7 +40,7 @@ public class MeetingController {
     @PostMapping("/{meetingId}/join")
     public ResponseEntity<SuccessBody<Void>> joinMeeting(
         @PathVariable("meetingId") Long meetingId,
-        Member member
+        @LoginMemberId Long memberId
     ){
         // Todo 지우님 전략 패턴 적용 후 코드 추가 예정
         return ApiResponseGenerator.success(HttpStatus.OK, "모임 참가 성공");
@@ -49,10 +50,10 @@ public class MeetingController {
     @PostMapping("/{meetingId}/confirm")
     public ResponseEntity<SuccessBody<Void>> decideMeeting(
         @PathVariable("meetingId") Long meetingId,
-        Member member,
+        @LoginMemberId Long memberId,
         ConfirmMeetingGetRequest confirmMeetingGetRequest
     ){
-        meetingService.decideMeeting(member, confirmMeetingGetRequest.confirmFoodId(),
+        meetingService.decideMeeting(memberId, confirmMeetingGetRequest.confirmFoodId(),
             confirmMeetingGetRequest.confirmDateTime(), meetingId);
         return ApiResponseGenerator.success(HttpStatus.OK, "모임 시간 확정 성공");
     }
@@ -61,9 +62,9 @@ public class MeetingController {
     @DeleteMapping("/{meetingId}")
     public ResponseEntity<SuccessBody<Void>> exitMeeting(
         @PathVariable("meetingId") Long meetingId,
-        Member member
+        @LoginMemberId Long memberId
     ){
-        meetingService.exitMeeting(member, meetingId);
+        meetingService.exitMeeting(memberId, meetingId);
         return ApiResponseGenerator.success(HttpStatus.OK, "모임 탈퇴 성공");
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -1,16 +1,20 @@
 package org.cookieandkakao.babting.domain.meeting.controller;
 
+import java.util.List;
 import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.SuccessBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
 import org.cookieandkakao.babting.domain.food.service.FoodService;
 import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingGetResponse;
+import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
 import org.cookieandkakao.babting.domain.meeting.service.MeetingService;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -69,10 +73,11 @@ public class MeetingController {
     }
 
     // 참여 모임 목록 조회
-//    @GetMapping
-//    public ResponseEntity<SuccessBody<MeetingGetResponse>> getAllMeeting(
-//        Member member
-//    ){
-//
-//    }
+    @GetMapping
+    public ResponseEntity<SuccessBody<List<MeetingGetResponse>>> getAllMeeting(
+        @LoginMemberId Long memberId
+    ){
+        List<MeetingGetResponse> meetings = meetingService.getAllMeetings(memberId);
+        return ApiResponseGenerator.success(HttpStatus.OK, "참여 모임 목록 조회 성공", meetings);
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/request/ConfirmMeetingGetRequest.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/request/ConfirmMeetingGetRequest.java
@@ -3,8 +3,9 @@ package org.cookieandkakao.babting.domain.meeting.dto.request;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
-public record ConfirmDateTimeGetRequest (
+public record ConfirmMeetingGetRequest(
     @NotNull
-    LocalDateTime confirmDateTime
+    LocalDateTime confirmDateTime,
+    Long confirmFoodId
 ) {
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/response/LocationGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/response/LocationGetResponse.java
@@ -1,5 +1,7 @@
 package org.cookieandkakao.babting.domain.meeting.dto.response;
 
+import org.cookieandkakao.babting.domain.meeting.entity.Location;
+
 public record LocationGetResponse(
     Long locationId,
 
@@ -11,4 +13,8 @@ public record LocationGetResponse(
 
     Double longitude
 ){
+    public static LocationGetResponse from(Location location){
+        return new LocationGetResponse(location.getLocationId(), location.getName(),
+            location.getAddress(), location.getLatitude(), location.getLongitude());
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/response/MeetingGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/response/MeetingGetResponse.java
@@ -1,21 +1,22 @@
 package org.cookieandkakao.babting.domain.meeting.dto.response;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
+import org.cookieandkakao.babting.domain.food.dto.FoodGetResponse;
+import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
 
 public record MeetingGetResponse(
     LocationGetResponse baseLocation,
 
     String title,
 
-    LocalDate startDate,
+    LocalDateTime confirmedDateTime,
 
-    LocalDate endDate,
-
-    Integer durationTime,
-
-    LocalTime startTime,
-
-    LocalTime endTime
+    FoodGetResponse confirmedFood
 ) {
+    public static MeetingGetResponse from(Meeting meeting) {
+        return new MeetingGetResponse(LocationGetResponse.from(meeting.getBaseLocation()),
+            meeting.getTitle(),
+            meeting.getConfirmDateTime(),
+            FoodGetResponse.from(meeting.getConfirmedFood()));
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Location.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Location.java
@@ -34,4 +34,24 @@ public class Location {
         this.latitude = latitude;
         this.longitude = longitude;
     }
+
+    public Long getLocationId() {
+        return locationId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
@@ -73,4 +73,16 @@ public class Meeting {
     public LocalDateTime getConfirmDateTime() {
         return confirmedDateTime;
     }
+
+    public Location getBaseLocation() {
+        return baseLocation;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Food getConfirmedFood() {
+        return confirmedFood;
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
@@ -66,6 +66,10 @@ public class Meeting {
         this.confirmDateTime = confirmDateTime;
     }
 
+    public void confirmFood (Food food){
+        this.confirmedFood = food;
+    }
+
     public LocalDateTime getConfirmDateTime() {
         return confirmDateTime;
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
@@ -12,6 +12,7 @@ import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import org.cookieandkakao.babting.domain.food.entity.Food;
 
 @Entity
 @Table(name = "meeting")
@@ -23,6 +24,10 @@ public class Meeting {
     @OneToOne
     @JoinColumn(name = "base_location_id")
     private Location baseLocation;
+
+    @OneToOne
+    @JoinColumn(name = "confirmed_food")
+    private Food confirmedFood;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
@@ -47,7 +47,7 @@ public class Meeting {
     private LocalTime endTime;
 
     @Column
-    private LocalDateTime confirmDateTime;
+    private LocalDateTime confirmedDateTime;
 
     protected Meeting(){}
 
@@ -62,8 +62,8 @@ public class Meeting {
         this.endTime = endTime;
     }
 
-    public void confirmDateTime(LocalDateTime confirmDateTime){
-        this.confirmDateTime = confirmDateTime;
+    public void confirmDateTime(LocalDateTime confirmedDateTime){
+        this.confirmedDateTime = confirmedDateTime;
     }
 
     public void confirmFood (Food food){
@@ -71,6 +71,6 @@ public class Meeting {
     }
 
     public LocalDateTime getConfirmDateTime() {
-        return confirmDateTime;
+        return confirmedDateTime;
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/MeetingEvent.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/MeetingEvent.java
@@ -17,11 +17,11 @@ public class MeetingEvent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long meetingEventId;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "member_meeting_id")
     private MemberMeeting memberMeeting;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "event_id")
     private Event event;
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/MemberMeeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/MemberMeeting.java
@@ -38,4 +38,8 @@ public class MemberMeeting {
     public boolean isHost() {
         return isHost;
     }
+
+    public Meeting getMeeting() {
+        return meeting;
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MeetingEventRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MeetingEventRepository.java
@@ -1,9 +1,12 @@
 package org.cookieandkakao.babting.domain.meeting.repository;
 
+import java.util.Optional;
 import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
+import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeetingEventRepository extends JpaRepository<MeetingEvent, Long> {
+    Optional<MeetingEvent> findByMemberMeeting(MemberMeeting memberMeeting);
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberMeetingRepository extends JpaRepository<MemberMeeting, Long> {
-    Optional<MemberMeeting> findMemberMeetingByMemberAndMeeting(Member member, Meeting meeting);
+    Optional<MemberMeeting> findByMemberAndMeeting(Member member, Meeting meeting);
     @Query("SELECT mm.meeting FROM MemberMeeting mm WHERE mm.member = :member")
     List<Meeting> findMeetingsByMember(@Param("member") Member member);
     boolean existsByMemberAndMeeting(Member member, Meeting meeting);

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
@@ -1,14 +1,19 @@
 package org.cookieandkakao.babting.domain.meeting.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
 import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberMeetingRepository extends JpaRepository<MemberMeeting, Long> {
     Optional<MemberMeeting> findMemberMeetingByMemberAndMeeting(Member member, Meeting meeting);
+    @Query("SELECT mm.meeting FROM MemberMeeting mm WHERE mm.member = :member")
+    List<Meeting> findMeetingsByMember(@Param("member") Member member);
     void deleteAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
@@ -15,5 +15,6 @@ public interface MemberMeetingRepository extends JpaRepository<MemberMeeting, Lo
     Optional<MemberMeeting> findMemberMeetingByMemberAndMeeting(Member member, Meeting meeting);
     @Query("SELECT mm.meeting FROM MemberMeeting mm WHERE mm.member = :member")
     List<Meeting> findMeetingsByMember(@Param("member") Member member);
+    boolean existsByMemberAndMeeting(Member member, Meeting meeting);
     void deleteAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -145,8 +145,4 @@ public class MeetingService {
     private Optional<MeetingEvent> findMeetingEvent(MemberMeeting memberMeeting){
         return meetingEventRepository.findByMemberMeeting(memberMeeting);
     }
-
-    private void saveMeetingEvent(Member member){
-        //Todo 모임일정추가 or 계산 로직 생각중...
-    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -2,10 +2,13 @@ package org.cookieandkakao.babting.domain.meeting.service;
 
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.service.FoodRepositoryService;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingGetResponse;
 import org.cookieandkakao.babting.domain.meeting.entity.Location;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
 import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
@@ -94,6 +97,14 @@ public class MeetingService {
         }
     }
 
+    // 모임 목록 조회
+    public List<MeetingGetResponse> getAllMeetings(Long memberId){
+        Member member = memberService.findMember(memberId);
+        List<Meeting> meetingList = memberMeetingRepository.findMeetingsByMember(member);
+        return meetingList.stream()
+            .map(MeetingGetResponse::from)
+            .collect(Collectors.toList());
+    }
     private Meeting findMeeting(Long meetingId){
         return meetingRepository.findById(meetingId)
             .orElseThrow(() -> new NoSuchElementException("해당 모임이 존재하지 않습니다."));

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -3,6 +3,8 @@ package org.cookieandkakao.babting.domain.meeting.service;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
+import org.cookieandkakao.babting.domain.food.entity.Food;
+import org.cookieandkakao.babting.domain.food.service.FoodRepositoryService;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.entity.Location;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
@@ -21,13 +23,17 @@ public class MeetingService {
     private final MeetingEventRepository meetingEventRepository;
     private final MemberMeetingRepository memberMeetingRepository;
     private final LocationRepository locationRepository;
+    private final FoodRepositoryService foodRepositoryService;
 
-    public MeetingService(MeetingRepository meetingRepository, MeetingEventRepository meetingEventRepository,
-        MemberMeetingRepository memberMeetingRepository, LocationRepository locationRepository) {
+    public MeetingService(MeetingRepository meetingRepository,
+        MeetingEventRepository meetingEventRepository,
+        MemberMeetingRepository memberMeetingRepository,
+        LocationRepository locationRepository, FoodRepositoryService foodRepositoryService) {
         this.meetingRepository = meetingRepository;
         this.meetingEventRepository = meetingEventRepository;
         this.memberMeetingRepository = memberMeetingRepository;
         this.locationRepository = locationRepository;
+        this.foodRepositoryService = foodRepositoryService;
     }
 
     // 모임 생성(주최자)
@@ -40,7 +46,7 @@ public class MeetingService {
         memberMeetingRepository.save(new MemberMeeting(member, meeting, true));
     }
     // 모임 시간 확정(주최자)
-    public void decideMeetingTime(Member member, LocalDateTime confirmDateTime, Long meetingId){
+    public void decideMeeting(Member member, Long confirmFoodId, LocalDateTime confirmDateTime, Long meetingId){
         Meeting meeting = findMeeting(meetingId);
 
         MemberMeeting memberMeeting = findMemberMeeting(member, meeting);
@@ -53,6 +59,10 @@ public class MeetingService {
             throw new IllegalStateException("이미 모임 시간이 확정되었습니다.");
         }
         
+        if (confirmFoodId != null){
+            Food food = foodRepositoryService.findFoodById(confirmFoodId);
+            meeting.confirmFood(food);
+        }
         meeting.confirmDateTime(confirmDateTime);
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -14,6 +14,7 @@ import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventReposito
 import org.cookieandkakao.babting.domain.meeting.repository.MeetingRepository;
 import org.cookieandkakao.babting.domain.meeting.repository.MemberMeetingRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,20 +25,24 @@ public class MeetingService {
     private final MemberMeetingRepository memberMeetingRepository;
     private final LocationRepository locationRepository;
     private final FoodRepositoryService foodRepositoryService;
+    private final MemberService memberService;
 
     public MeetingService(MeetingRepository meetingRepository,
         MeetingEventRepository meetingEventRepository,
         MemberMeetingRepository memberMeetingRepository,
-        LocationRepository locationRepository, FoodRepositoryService foodRepositoryService) {
+        LocationRepository locationRepository, FoodRepositoryService foodRepositoryService,
+        MemberService memberService) {
         this.meetingRepository = meetingRepository;
         this.meetingEventRepository = meetingEventRepository;
         this.memberMeetingRepository = memberMeetingRepository;
         this.locationRepository = locationRepository;
         this.foodRepositoryService = foodRepositoryService;
+        this.memberService = memberService;
     }
 
     // 모임 생성(주최자)
-    public void createMeeting(Member member, MeetingCreateRequest meetingCreateRequest){
+    public void createMeeting(Long memberId, MeetingCreateRequest meetingCreateRequest){
+        Member member = memberService.findMember(memberId);
         Meeting meeting = meetingCreateRequest.toEntity();
         Location baseLocation = meetingCreateRequest.baseLocation().toEntity();
 
@@ -46,7 +51,8 @@ public class MeetingService {
         memberMeetingRepository.save(new MemberMeeting(member, meeting, true));
     }
     // 모임 시간 확정(주최자)
-    public void decideMeeting(Member member, Long confirmFoodId, LocalDateTime confirmDateTime, Long meetingId){
+    public void decideMeeting(Long memberId, Long confirmFoodId, LocalDateTime confirmDateTime, Long meetingId){
+        Member member = memberService.findMember(memberId);
         Meeting meeting = findMeeting(meetingId);
 
         MemberMeeting memberMeeting = findMemberMeeting(member, meeting);
@@ -67,13 +73,15 @@ public class MeetingService {
     }
 
     // 모임 참가(초대받은사람)
-    public void joinMeeting(Member member, Long meetingId){
+    public void joinMeeting(Long memberId, Long meetingId){
+        Member member = memberService.findMember(memberId);
         Meeting meeting = findMeeting(meetingId);
         //Todo 초대받았는지 확인하는 로직 추가
         memberMeetingRepository.save(new MemberMeeting(member, meeting, false));
     }
     // 모임 탈퇴(주최자, 초대받은 사람)
-    public void exitMeeting(Member member, Long meetingId){
+    public void exitMeeting(Long memberId, Long meetingId){
+        Member member = memberService.findMember(memberId);
         Meeting meeting = findMeeting(meetingId);
         MemberMeeting memberMeeting = findMemberMeeting(member, meeting);
         if (memberMeeting.isHost()){

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -50,7 +50,7 @@ public class MeetingService {
         meetingRepository.save(meeting);
         memberMeetingRepository.save(new MemberMeeting(member, meeting, true));
     }
-    // 모임 시간 확정(주최자)
+    // 모임 확정(주최자)
     public void decideMeeting(Long memberId, Long confirmFoodId, LocalDateTime confirmDateTime, Long meetingId){
         Member member = memberService.findMember(memberId);
         Meeting meeting = findMeeting(meetingId);

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -117,7 +117,7 @@ public class MeetingService {
     }
 
     private MemberMeeting findMemberMeeting(Member member, Meeting meeting){
-        return memberMeetingRepository.findMemberMeetingByMemberAndMeeting(member, meeting)
+        return memberMeetingRepository.findByMemberAndMeeting(member, meeting)
             .orElseThrow(() -> new NoSuchElementException("해당 모임에 회원이 존재하지 않습니다."));
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -84,6 +84,8 @@ public class MeetingService {
         if (isJoinMeeting){
             throw new IllegalStateException("이미 모임에 참가한 상태입니다.");
         }
+
+        // Todo 모임 참가시 모임 선호/비선호 음식 추가
         memberMeetingRepository.save(new MemberMeeting(member, meeting, false));
     }
     // 모임 탈퇴(주최자, 초대받은 사람)

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -3,7 +3,6 @@ package org.cookieandkakao.babting.domain.meeting.service;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
-import org.cookieandkakao.babting.domain.meeting.dto.request.LocationCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.entity.Location;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
@@ -41,14 +40,12 @@ public class MeetingService {
         memberMeetingRepository.save(new MemberMeeting(member, meeting, true));
     }
     // 모임 시간 확정(주최자)
-    // Todo 예외처리
     public void decideMeetingTime(Member member, LocalDateTime confirmDateTime, Long meetingId){
         Meeting meeting = findMeeting(meetingId);
 
         MemberMeeting memberMeeting = findMemberMeeting(member, meeting);
 
         if (!memberMeeting.isHost()){
-            //Todo 예외처리
             throw new IllegalStateException("권한이 없습니다.");
         }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -79,7 +79,11 @@ public class MeetingService {
     public void joinMeeting(Long memberId, Long meetingId){
         Member member = memberService.findMember(memberId);
         Meeting meeting = findMeeting(meetingId);
-        //Todo 초대받았는지 확인하는 로직 추가
+
+        boolean isJoinMeeting = memberMeetingRepository.existsByMemberAndMeeting(member, meeting);
+        if (isJoinMeeting){
+            throw new IllegalStateException("이미 모임에 참가한 상태입니다.");
+        }
         memberMeetingRepository.save(new MemberMeeting(member, meeting, false));
     }
     // 모임 탈퇴(주최자, 초대받은 사람)


### PR DESCRIPTION
## 주요 변경사항
1. 모임 - 음식 연관관계 추가 (확정 음식)
2. 30f99d98dc49681228f48c9d8b4ce5d8bae91c7c 정적팩토리 메서드 적용 entity -> dto / https://github.com/kakao-tech-campus-2nd-step3/Team16_BE/commit/69f355e60b2fa144af0772d673e17ec781018141#r147850833 왼쪽 커밋 보시면 왜 정적팩토리 메서드를 적용했는지 볼 수 있습니다! 저는 저런 식으로 많이 사용하는데 어떤지 의견 여쭤보아요.
3. a 모임에 참가한 회원이 또 a에 참가하려고할 때 예외 처리
4. 모임 참가 시 모임_선호/비선호_음식에 선호/비선호 음식 추가해야하는데 지우님 코드 합쳐지면 추가 예정
5. 회원_모임(MemberMeeting) - 모임_일정(MeetingEvent) 연관관계 변경  : 일대다 -> 일대일  
모임_일정(MeetingEvent) - 일정(Event) 연관관계 변경  : 일대일 -> 다대일
7. 모임 탈퇴 기능 구현 중입니다....
모임 탈퇴 시 주최자인지, 참가자인지/ 모임이 확정됐는지 아닌지.. 에 따라 if else문이 복잡하게 구현되어야해서 다음 번에 구현해보겠습니다!
## 리뷰어에게...
2번을 중점적으로 리뷰해주셨으면 좋겠습니다!!


