### PR TITLE
[FEAT] RestClientConfig 추가, 테스트 코드 추가 및 수정, 모임 확정 시 캘린더에 일정 추가 부분 수정

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/common/cache/RedisConfig.java
+++ b/src/main/java/org/cookieandkakao/babting/common/cache/RedisConfig.java
@@ -1,31 +1,23 @@
 package org.cookieandkakao.babting.common.cache;
 
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.time.Duration;
 
 @Configuration
 @EnableCaching
 public class RedisConfig {
 
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(5))
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.json()));
-
-        return RedisCacheManager.builder(redisConnectionFactory)
-            .cacheDefaults(cacheConfiguration)
-            .build();
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/common/config/RestClientConfig.java
+++ b/src/main/java/org/cookieandkakao/babting/common/config/RestClientConfig.java
@@ -1,0 +1,24 @@
+package org.cookieandkakao.babting.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient kakaoRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000); // 5초
+        factory.setReadTimeout(5000); // 5초
+
+        return RestClient.builder()
+            .baseUrl("https://kapi.kakao.com")
+            .defaultHeader("Content-Type", "application/json")
+            .requestFactory(factory)
+            .build();
+    }
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
@@ -47,7 +47,7 @@ public class TalkCalendarController {
         EventListGetResponse eventList = new EventListGetResponse(updatedEvents);
 
         if (updatedEvents.isEmpty()) {
-            return ApiResponseGenerator.success(HttpStatus.OK, "조회된 일정이 없습니다.", eventList);
+            return ApiResponseGenerator.success(HttpStatus.OK, "조회된 일정 목록이 없습니다.", eventList);
         }
 
         return ApiResponseGenerator.success(HttpStatus.OK, "일정 목록을 조회했습니다.", eventList);
@@ -66,7 +66,7 @@ public class TalkCalendarController {
                 eventDetailGetResponse);
         }
 
-        return ApiResponseGenerator.success(HttpStatus.OK, "일정 목록을 조회했습니다.",
+        return ApiResponseGenerator.success(HttpStatus.OK, "일정을 조회했습니다.",
             eventDetailGetResponse);
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarController.java
@@ -42,7 +42,8 @@ public class TalkCalendarController {
         @LoginMemberId Long memberId
     ) {
 
-        List<EventGetResponse> updatedEvents = talkCalendarService.getUpdatedEventList(from, to, memberId);
+        List<EventGetResponse> updatedEvents = talkCalendarService.getUpdatedEventList(from, to,
+            memberId);
         EventListGetResponse eventList = new EventListGetResponse(updatedEvents);
 
         if (updatedEvents.isEmpty()) {
@@ -57,14 +58,16 @@ public class TalkCalendarController {
         @PathVariable("event_id") String eventId,
         @LoginMemberId Long memberId
     ) {
-        EventDetailGetResponse eventDetailGetResponse = talkCalendarService.getEvent(memberId, eventId);
+        EventDetailGetResponse eventDetailGetResponse = talkCalendarService.getEvent(memberId,
+            eventId);
 
         if (eventDetailGetResponse == null) {
             return ApiResponseGenerator.success(HttpStatus.OK, "조회된 일정이 없습니다.",
                 eventDetailGetResponse);
         }
 
-        return ApiResponseGenerator.success(HttpStatus.OK, "일정 목록을 조회했습니다.", eventDetailGetResponse);
+        return ApiResponseGenerator.success(HttpStatus.OK, "일정 목록을 조회했습니다.",
+            eventDetailGetResponse);
     }
 
     @PostMapping("/events")
@@ -73,7 +76,8 @@ public class TalkCalendarController {
         @LoginMemberId Long memberId
     ) {
         // 카카오 api로 일정 생성
-        EventCreateResponse eventCreateResponse = talkCalendarService.createEvent(eventRequestDto, memberId);
+        EventCreateResponse eventCreateResponse = talkCalendarService.createEvent(eventRequestDto,
+            memberId);
         return ApiResponseGenerator.success(HttpStatus.CREATED, "일정이 성공적으로 생성되었습니다.",
             eventCreateResponse);
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/request/EventCreateRequest.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/request/EventCreateRequest.java
@@ -2,6 +2,7 @@ package org.cookieandkakao.babting.domain.calendar.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record EventCreateRequest(
     @NotBlank(message = "제목은 비어있으면 안됩니다!")
@@ -11,6 +12,8 @@ public record EventCreateRequest(
     TimeCreateRequest time,
 
     String rrule,
+
+    List<Integer> reminders,
 
     String description
 ) {

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/request/TimeCreateRequest.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/request/TimeCreateRequest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import org.cookieandkakao.babting.common.util.TimeFormatterUtil;
 import org.cookieandkakao.babting.domain.calendar.entity.Time;
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/EventCreateResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/EventCreateResponse.java
@@ -1,5 +1,9 @@
 package org.cookieandkakao.babting.domain.calendar.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record EventCreateResponse(
     String eventId
 ) {

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/EventGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/EventGetResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
 import org.cookieandkakao.babting.domain.calendar.entity.Event;
 import org.cookieandkakao.babting.domain.calendar.entity.PersonalCalendar;
-import org.cookieandkakao.babting.domain.calendar.entity.Reminder;
 import org.cookieandkakao.babting.domain.calendar.entity.Time;
 import org.cookieandkakao.babting.domain.meeting.dto.response.LocationGetResponse;
 import org.cookieandkakao.babting.domain.meeting.entity.Location;

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/EventGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/EventGetResponse.java
@@ -2,6 +2,7 @@ package org.cookieandkakao.babting.domain.calendar.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
 import org.cookieandkakao.babting.domain.calendar.entity.Event;
 import org.cookieandkakao.babting.domain.calendar.entity.PersonalCalendar;
 import org.cookieandkakao.babting.domain.calendar.entity.Reminder;
@@ -34,7 +35,7 @@ public record EventGetResponse(
 
     LocationGetResponse location,
 
-    Reminder reminders,
+    List<Integer> reminders,
 
     String color,
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/TimeGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/TimeGetResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import org.cookieandkakao.babting.common.util.TimeFormatterUtil;
 import org.cookieandkakao.babting.domain.calendar.entity.Time;
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/entity/Reminder.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/entity/Reminder.java
@@ -22,17 +22,17 @@ public class Reminder {
     private Event event;
 
     @Column
-    private Long remindTime;
+    private Integer remindTime;
 
     protected Reminder() {
     }
 
-    public Reminder(Event event, Long remindTime) {
+    public Reminder(Event event, Integer remindTime) {
         this.event = event;
         this.remindTime = remindTime;
     }
 
-    public Long getRemindTime() {
+    public Integer getRemindTime() {
         return remindTime;
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/EventService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/EventService.java
@@ -64,9 +64,12 @@ public class EventService {
         eventRepository.save(event);
 
         // Reminder 저장 (있을 경우)
-        if (eventGetResponse.reminders() != null) {
-            reminderRepository.save(
-                new Reminder(event, eventGetResponse.reminders().getRemindTime()));
+        for (Integer reminderTime : eventGetResponse.reminders()) {
+            if (reminderTime != null) {
+                reminderRepository.save(
+                    new Reminder(event, reminderTime)
+                );
+            }
         }
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarService.java
@@ -1,6 +1,5 @@
 package org.cookieandkakao.babting.domain.calendar.service;
 
-import org.cookieandkakao.babting.common.exception.customexception.MemberNotFoundException;
 import org.cookieandkakao.babting.domain.calendar.entity.PersonalCalendar;
 import org.cookieandkakao.babting.domain.calendar.repository.PersonalCalendarRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
@@ -2,9 +2,9 @@ package org.cookieandkakao.babting.domain.calendar.service;
 
 
 import java.net.URI;
-import java.util.Map;
 import org.cookieandkakao.babting.common.exception.customexception.ApiException;
 import org.cookieandkakao.babting.common.properties.KakaoProviderProperties;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventDetailGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventListGetResponse;
 import org.springframework.http.HttpHeaders;
@@ -56,18 +56,18 @@ public class TalkCalendarClientService {
         }
     }
 
-    public Map<String, Object> createEvent(String accessToken,
+    public EventCreateResponse createEvent(String accessToken,
         MultiValueMap<String, String> formData) {
         String url = kakaoProviderProperties.calendarCreateEventUri();
         URI uri = URI.create(url);
         try {
-            ResponseEntity<Map> response = restClient.post()
+            ResponseEntity<EventCreateResponse> response = restClient.post()
                 .uri(uri)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .body(formData)
                 .retrieve()
-                .toEntity(Map.class);
+                .toEntity(EventCreateResponse.class);
             return response.getBody();
         } catch (RestClientException e) {
             throw new ApiException("일정 생성 중 오류 발생 : " + e.getMessage());

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class TalkCalendarClientService {
@@ -74,12 +75,18 @@ public class TalkCalendarClientService {
     }
 
     private URI buildUri(String baseUrl, String from, String to) {
-        return URI.create(
-            String.format("%s?from=%s&to=%s&limit=100&time_zone=Asia/Seoul", baseUrl, from, to));
+        return UriComponentsBuilder.fromHttpUrl(baseUrl)
+            .queryParam("from",from)
+            .queryParam("to", to)
+            .queryParam("limit", 100)
+            .queryParam("time_zone", "Asia/Seoul")
+            .build().toUri();
     }
 
     private URI buildGetEventUri(String baseUrl, String eventId) {
-        return URI.create(String.format("%s?event_id=%s", baseUrl, eventId));
+        return UriComponentsBuilder.fromHttpUrl(baseUrl)
+            .queryParam("event_id", eventId)
+            .build().toUri();
     }
 
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
@@ -36,7 +36,7 @@ public class TalkCalendarClientService {
                 .toEntity(EventListGetResponse.class);
             return response.getBody();
         } catch (RestClientException e) {
-            throw new ApiException("API 호출 중 오류 발생");
+            throw new ApiException("일정 목록 조회 중 에러 발생 : " + e.getMessage());
         }
     }
 
@@ -52,7 +52,7 @@ public class TalkCalendarClientService {
                 .toEntity(EventDetailGetResponse.class);
             return response.getBody();
         } catch (RestClientException e) {
-            throw new ApiException("API 호출 중 오류 발생");
+            throw new ApiException("일정 상세 조회 중 오류 발생 : " + e.getMessage());
         }
     }
 
@@ -70,7 +70,7 @@ public class TalkCalendarClientService {
                 .toEntity(Map.class);
             return response.getBody();
         } catch (RestClientException e) {
-            throw new ApiException("API 호출 중 오류 발생");
+            throw new ApiException("일정 생성 중 오류 발생 : " + e.getMessage());
         }
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientService.java
@@ -1,7 +1,5 @@
 package org.cookieandkakao.babting.domain.calendar.service;
 
-
-import java.net.URI;
 import org.cookieandkakao.babting.common.exception.customexception.ApiException;
 import org.cookieandkakao.babting.common.properties.KakaoProviderProperties;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
@@ -13,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class TalkCalendarClientService {
@@ -32,7 +29,7 @@ public class TalkCalendarClientService {
         try {
             ResponseEntity<EventListGetResponse> response = restClient.get()
                 .uri(uriBuilder -> uriBuilder.path(relativeUrl)
-                    .queryParam("from",from)
+                    .queryParam("from", from)
                     .queryParam("to", to)
                     .queryParam("limit", 100)
                     .queryParam("time_zone", "Asia/Seoul")

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
@@ -27,7 +27,8 @@ public class TalkCalendarService {
     private final EventService eventService;
     private final MemberService memberService;
 
-    public TalkCalendarService(EventService eventService, TalkCalendarClientService talkCalendarClientService,
+    public TalkCalendarService(EventService eventService,
+        TalkCalendarClientService talkCalendarClientService,
         MemberService memberService) {
         this.eventService = eventService;
         this.talkCalendarClientService = talkCalendarClientService;
@@ -38,7 +39,8 @@ public class TalkCalendarService {
     @Cacheable(value = "eventListCache", key = "#memberId")
     public List<EventGetResponse> getUpdatedEventList(String from, String to, Long memberId) {
         String kakaoAccessToken = getKakaoAccessToken(memberId);
-        EventListGetResponse eventList = talkCalendarClientService.getEventList(kakaoAccessToken, from, to);
+        EventListGetResponse eventList = talkCalendarClientService.getEventList(kakaoAccessToken,
+            from, to);
         List<EventGetResponse> updatedEvents = new ArrayList<>();
 
         for (EventGetResponse event : eventList.events()) {
@@ -69,7 +71,8 @@ public class TalkCalendarService {
         String eventJson = convertToJSONString(eventCreateRequest);
         // event라는 key로 JSON 데이터를 추가
         formData.add("event", eventJson);
-        EventCreateResponse responseBody =talkCalendarClientService.createEvent(kakaoAccessToken, formData);
+        EventCreateResponse responseBody = talkCalendarClientService.createEvent(kakaoAccessToken,
+            formData);
         if (responseBody != null) {
             return responseBody;
         }
@@ -84,6 +87,7 @@ public class TalkCalendarService {
             throw new JsonConversionException("JSON 변환 중 오류가 발생했습니다.");
         }
     }
+
     private String getKakaoAccessToken(Long memberId) {
         KakaoToken kakaoToken = memberService.getKakaoToken(memberId);
         String kakaoAccessToken = kakaoToken.getAccessToken();

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.cookieandkakao.babting.common.exception.customexception.EventCreationException;
 import org.cookieandkakao.babting.common.exception.customexception.JsonConversionException;
 import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
@@ -70,12 +69,9 @@ public class TalkCalendarService {
         String eventJson = convertToJSONString(eventCreateRequest);
         // event라는 key로 JSON 데이터를 추가
         formData.add("event", eventJson);
-        // 응답에서 event_id 추출
-        Map<String, Object> responseBody =talkCalendarClientService.createEvent(kakaoAccessToken, formData);
-        if (responseBody != null && responseBody.containsKey("event_id")) {
-            String eventId = responseBody.get("event_id").toString();
-            // EventCreateResponseDto로 응답 반환
-            return new EventCreateResponse(eventId);
+        EventCreateResponse responseBody =talkCalendarClientService.createEvent(kakaoAccessToken, formData);
+        if (responseBody != null) {
+            return responseBody;
         }
         throw new EventCreationException("Event 생성 중 오류 발생: 응답에서 event_id가 없습니다.");
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -69,9 +69,10 @@ public class MeetingController {
     @PostMapping("/{meetingId}/confirm")
     public ResponseEntity<SuccessBody<Void>> confirmMeeting(
         @PathVariable("meetingId") Long meetingId,
+        @RequestBody ConfirmMeetingGetRequest confirmMeetingGetRequest,
         @LoginMemberId Long memberId
     ) {
-        meetingService.confirmMeeting(memberId, meetingId);
+        meetingService.confirmMeeting(memberId, meetingId, confirmMeetingGetRequest);
         return ApiResponseGenerator.success(HttpStatus.OK, "모임 확정 성공");
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/request/MeetingEventCreateRequest.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/request/MeetingEventCreateRequest.java
@@ -2,13 +2,16 @@ package org.cookieandkakao.babting.domain.meeting.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record MeetingEventCreateRequest(
     @NotBlank(message = "제목은 비어있으면 안됩니다!")
     String title,
 
     @NotNull(message = "시간은 필수입니다.")
-    MeetingTimeCreateRequest time
+    MeetingTimeCreateRequest time,
+
+    List<Integer> reminders
 
 ) {
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/Meeting.java
@@ -86,4 +86,8 @@ public class Meeting {
     public Food getConfirmedFood() {
         return confirmedFood;
     }
+
+    public Integer getDurationTime() {
+        return durationTime;
+    }
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarControllerTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/controller/TalkCalendarControllerTest.java
@@ -1,0 +1,167 @@
+package org.cookieandkakao.babting.domain.calendar.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.SuccessBody;
+import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
+import org.cookieandkakao.babting.domain.calendar.dto.request.TimeCreateRequest;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventDetailGetResponse;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventListGetResponse;
+import org.cookieandkakao.babting.domain.calendar.service.EventService;
+import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class TalkCalendarControllerTest {
+
+    @Mock
+    private TalkCalendarService talkCalendarService;
+
+    @Mock
+    private EventService eventService;
+
+    @InjectMocks
+    private TalkCalendarController talkCalendarController;
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Test
+    void getEventListTest_HasEvent() {
+        // Given
+        String from = "test From";
+        String to = "test To";
+        EventGetResponse eventGetResponse = new EventGetResponse("testId", "Test Title",
+            "USER", null, null, false, false, null, null,
+            "Test Description", null, null, "TestColor", null);
+        List<EventGetResponse> eventGetResponseList = List.of(eventGetResponse);
+        EventListGetResponse eventListGetResponse = new EventListGetResponse(eventGetResponseList);
+
+        // Mocking
+        given(talkCalendarService.getUpdatedEventList(from, to, MEMBER_ID)).willReturn(
+            eventGetResponseList);
+
+        // When
+        ResponseEntity<SuccessBody<EventListGetResponse>> result = talkCalendarController.getEventList(
+            from, to, MEMBER_ID);
+
+        // Then
+        verify(talkCalendarService).getUpdatedEventList(any(), any(), any());
+        assert result.getBody() != null;
+        assert result.getStatusCode() == HttpStatus.OK;
+        assert result.getBody().getData().equals(eventListGetResponse);
+        assert result.getBody().getData().events().size() == 1;
+        assert result.getBody().getData().events().getFirst().id().equals("testId");
+        assert result.getBody().getData().events().getFirst().title().equals("Test Title");
+        assert result.getBody().getMessage().equals("일정 목록을 조회했습니다.");
+    }
+
+    @Test
+    void getEventListTest_NoEvent() {
+        // Given
+        String from = "test From";
+        String to = "test To";
+
+        // Mocking
+        given(talkCalendarService.getUpdatedEventList(from, to, MEMBER_ID)).willReturn(
+            Collections.emptyList());
+
+        // When
+        ResponseEntity<SuccessBody<EventListGetResponse>> result = talkCalendarController.getEventList(
+            from, to, MEMBER_ID);
+
+        // Then
+        verify(talkCalendarService).getUpdatedEventList(any(), any(), any());
+        assert result.getBody() != null;
+        assert result.getStatusCode() == HttpStatus.OK;
+        assert result.getBody().getData().events().equals(Collections.emptyList());
+        assert result.getBody().getData().events().isEmpty();
+        assert result.getBody().getMessage().equals("조회된 일정 목록이 없습니다.");
+    }
+
+    @Test
+    void getEventTest_HasEvent() {
+        // Given
+        String eventId = "testId";
+        EventGetResponse eventGetResponse = new EventGetResponse("testId", "Test Title",
+            "USER", null, null, false, false, null, null,
+            "Test Description", null, null, "TestColor", null);
+        EventDetailGetResponse eventDetailGetResponse = new EventDetailGetResponse(
+            eventGetResponse);
+
+        // Mocking
+        given(talkCalendarService.getEvent(MEMBER_ID, eventId)).willReturn(eventDetailGetResponse);
+
+        // When
+        ResponseEntity<SuccessBody<EventDetailGetResponse>> result = talkCalendarController.getEvent(
+            eventId, MEMBER_ID);
+
+        // Then
+        verify(talkCalendarService).getEvent(MEMBER_ID, eventId);
+        assert result.getBody() != null;
+        assert result.getStatusCode() == HttpStatus.OK;
+        assert result.getBody().getData().equals(eventDetailGetResponse);
+        assert result.getBody().getData().event().equals(eventGetResponse);
+        assert result.getBody().getData().event().id().equals("testId");
+        assert result.getBody().getData().event().title().equals("Test Title");
+        assert result.getBody().getMessage().equals("일정을 조회했습니다.");
+    }
+
+    @Test
+    void getEventTest_NoEvent() {
+        // Given
+        String eventId = "testId";
+
+        // Mocking
+        given(talkCalendarService.getEvent(MEMBER_ID, eventId)).willReturn(null);
+
+        // When
+        ResponseEntity<SuccessBody<EventDetailGetResponse>> result = talkCalendarController.getEvent(
+            eventId, MEMBER_ID);
+
+        // Then
+        verify(talkCalendarService).getEvent(MEMBER_ID, eventId);
+        assert result.getBody() != null;
+        assert result.getStatusCode() == HttpStatus.OK;
+        ;
+        assert result.getBody().getData() == null;
+        assert result.getBody().getMessage().equals("조회된 일정이 없습니다.");
+    }
+
+    @Test
+    void createEventTest() {
+        // Given
+        TimeCreateRequest timeRequest = new TimeCreateRequest("2024-10-01T00:00:00Z",
+            "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        EventCreateRequest eventCreateRequest = new EventCreateRequest("testTitle", timeRequest,
+            null, List.of(10), null);
+        EventCreateResponse eventCreateResponse = new EventCreateResponse("testId");
+
+        // Mocking
+        given(talkCalendarService.createEvent(eventCreateRequest, MEMBER_ID)).willReturn(
+            eventCreateResponse);
+
+        // When
+        ResponseEntity<SuccessBody<EventCreateResponse>> result = talkCalendarController.createEvent(
+            eventCreateRequest, MEMBER_ID);
+
+        // Then
+        verify(talkCalendarService).createEvent(eventCreateRequest, MEMBER_ID);
+        assert result.getBody() != null;
+        assert result.getStatusCode() == HttpStatus.CREATED;
+        assert result.getBody().getData().equals(eventCreateResponse);
+        assert result.getBody().getMessage().equals("일정이 성공적으로 생성되었습니다.");
+    }
+
+}

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/entity/ReminderTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/entity/ReminderTest.java
@@ -1,6 +1,5 @@
 package org.cookieandkakao.babting.domain.calendar.entity;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/entity/ReminderTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/entity/ReminderTest.java
@@ -16,7 +16,7 @@ class ReminderTest {
         Event event = new Event(new PersonalCalendar(new Member(1L)),
             new Time(LocalDateTime.now(), LocalDateTime.now().plusHours(1), "Asia/Seoul", false),
             null, "12345", "Test Event", false, null, null, null, null, null);
-        Long remindTime = 60L;
+        Integer remindTime = 60;
 
         // When
         Reminder reminder = new Reminder(event, remindTime);

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/EventServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/EventServiceTest.java
@@ -1,6 +1,9 @@
 package org.cookieandkakao.babting.domain.calendar.service;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -24,6 +27,8 @@ import org.cookieandkakao.babting.domain.meeting.entity.Location;
 import org.cookieandkakao.babting.domain.meeting.repository.LocationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -50,6 +55,10 @@ class EventServiceTest {
 
     @Mock
     private PersonalCalendarService personalCalendarService;
+
+    // 메서드 인자 값 확인 위해 사용
+    @Captor
+    ArgumentCaptor<Event> eventCaptor;
 
     // Mock 객체 초기화
     @BeforeEach
@@ -90,6 +99,14 @@ class EventServiceTest {
         verify(locationRepository).save(any(Location.class));
         verify(eventRepository).save(any(Event.class));
         verify(reminderRepository, times(0)).save(any(Reminder.class));
+
+        // 객체 내용 검증
+        verify(eventRepository).save(eventCaptor.capture());
+        Event event = eventCaptor.getValue();
+        assertEquals("testTitle", event.getTitle());
+        assertEquals("testDescription", event.getDescription());
+        assertEquals("testId", event.getKakaoEventId());
+        assertNull(event.getScheduleRepeatCycle());
     }
 
     @Test
@@ -117,6 +134,13 @@ class EventServiceTest {
         verify(timeRepository).save(any(Time.class));
         verify(eventRepository).save(any(Event.class));
 
+        // 객체 내용 검증
+        verify(eventRepository).save(eventCaptor.capture());
+        Event event = eventCaptor.getValue();
+        assertEquals("testTitle", event.getTitle());
+        assertEquals("testDescription", event.getDescription());
+        assertEquals("testId", event.getKakaoEventId());
+        assertNull(event.getScheduleRepeatCycle());
     }
 
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/EventServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/EventServiceTest.java
@@ -2,7 +2,6 @@ package org.cookieandkakao.babting.domain.calendar.service;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -152,10 +151,12 @@ class EventServiceTest {
         EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willThrow(new IllegalArgumentException("개인 캘린더 찾을 수 없음"));
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willThrow(
+            new IllegalArgumentException("개인 캘린더 찾을 수 없음"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveEvent(eventGetResponseMock, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -172,10 +173,12 @@ class EventServiceTest {
         EventCreateRequest eventCreateRequestMock = mock(EventCreateRequest.class);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willThrow(new IllegalArgumentException("개인 캘린더 찾을 수 없음"));
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willThrow(
+            new IllegalArgumentException("개인 캘린더 찾을 수 없음"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -191,17 +194,21 @@ class EventServiceTest {
         Long memberId = 1L;
         EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
         PersonalCalendar personalCalendar = new PersonalCalendar(null);
-        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z",
+            "Asia/Seoul", false);
         LocationGetResponse location = new LocationGetResponse(null, "test", "test", 30.0, 32.2);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
+            personalCalendar);
         given(eventGetResponseMock.time()).willReturn(time);
         given(eventGetResponseMock.location()).willReturn(location);
-        given(locationRepository.save(any(Location.class))).willThrow(new IllegalArgumentException("위치 저장 실패"));
+        given(locationRepository.save(any(Location.class))).willThrow(
+            new IllegalArgumentException("위치 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveEvent(eventGetResponseMock, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -218,17 +225,21 @@ class EventServiceTest {
         Long memberId = 1L;
         EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
         PersonalCalendar personalCalendar = new PersonalCalendar(null);
-        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z",
+            "Asia/Seoul", false);
         LocationGetResponse location = new LocationGetResponse(null, "test", "test", 30.0, 32.2);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
+            personalCalendar);
         given(eventGetResponseMock.time()).willReturn(time);
         given(eventGetResponseMock.location()).willReturn(location);
-        given(eventRepository.save(any(Event.class))).willThrow(new IllegalArgumentException("일정 저장 실패"));
+        given(eventRepository.save(any(Event.class))).willThrow(
+            new IllegalArgumentException("일정 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveEvent(eventGetResponseMock, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -253,10 +264,12 @@ class EventServiceTest {
         given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
             personalCalendar);
         given(eventCreateRequestMock.time()).willReturn(time);
-        given(eventRepository.save(any(Event.class))).willThrow(new IllegalArgumentException("일정 저장 실패"));
+        given(eventRepository.save(any(Event.class))).willThrow(
+            new IllegalArgumentException("일정 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -272,16 +285,20 @@ class EventServiceTest {
         Long memberId = 1L;
         EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
         PersonalCalendar personalCalendar = new PersonalCalendar(null);
-        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z",
+            "Asia/Seoul", false);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
+            personalCalendar);
         given(eventGetResponseMock.time()).willReturn(time);
         given(eventGetResponseMock.reminders()).willReturn(List.of(5, 10));
-        given(reminderRepository.save(any(Reminder.class))).willThrow(new IllegalArgumentException("리마인더 저장 실패"));
+        given(reminderRepository.save(any(Reminder.class))).willThrow(
+            new IllegalArgumentException("리마인더 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveEvent(eventGetResponseMock, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -299,15 +316,19 @@ class EventServiceTest {
         Long memberId = 1L;
         EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
         PersonalCalendar personalCalendar = new PersonalCalendar(null);
-        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z",
+            "Asia/Seoul", false);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
+            personalCalendar);
         given(eventGetResponseMock.time()).willReturn(time);
-        given(timeRepository.save(any(Time.class))).willThrow(new IllegalArgumentException("시간 저장 실패"));
+        given(timeRepository.save(any(Time.class))).willThrow(
+            new IllegalArgumentException("시간 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveEvent(eventGetResponseMock, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -324,15 +345,19 @@ class EventServiceTest {
         String eventId = "testId";
         EventCreateRequest eventCreateRequestMock = mock(EventCreateRequest.class);
         PersonalCalendar personalCalendar = new PersonalCalendar(null);
-        TimeCreateRequest time = new TimeCreateRequest("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        TimeCreateRequest time = new TimeCreateRequest("2024-10-01T00:00:00Z",
+            "2024-10-01T03:00:00Z", "Asia/Seoul", false);
 
         // Mocking
-        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
+            personalCalendar);
         given(eventCreateRequestMock.time()).willReturn(time);
-        given(timeRepository.save(any(Time.class))).willThrow(new IllegalArgumentException("시간 저장 실패"));
+        given(timeRepository.save(any(Time.class))).willThrow(
+            new IllegalArgumentException("시간 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId,memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/EventServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/EventServiceTest.java
@@ -4,12 +4,14 @@ package org.cookieandkakao.babting.domain.calendar.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
 import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
 import org.cookieandkakao.babting.domain.calendar.dto.request.TimeCreateRequest;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
@@ -141,6 +143,203 @@ class EventServiceTest {
         assertEquals("testDescription", event.getDescription());
         assertEquals("testId", event.getKakaoEventId());
         assertNull(event.getScheduleRepeatCycle());
+    }
+
+    @Test
+    void saveEventTest_NotFoundPersonalCalendar() {
+        // Given
+        Long memberId = 1L;
+        EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willThrow(new IllegalArgumentException("개인 캘린더 찾을 수 없음"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "개인 캘린더 찾을 수 없음");
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(eventRepository, times(0)).save(any(Event.class));
+    }
+
+    @Test
+    void saveCreatedEventTest_NotFoundPersonalCalendar() {
+        // Given
+        Long memberId = 1L;
+        String eventId = "testId";
+        EventCreateRequest eventCreateRequestMock = mock(EventCreateRequest.class);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willThrow(new IllegalArgumentException("개인 캘린더 찾을 수 없음"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "개인 캘린더 찾을 수 없음");
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository, times(0)).save(any(Time.class));
+        verify(eventRepository, times(0)).save(any(Event.class));
+    }
+
+    @Test
+    void saveEventTest_LocationSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
+        PersonalCalendar personalCalendar = new PersonalCalendar(null);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        LocationGetResponse location = new LocationGetResponse(null, "test", "test", 30.0, 32.2);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(eventGetResponseMock.time()).willReturn(time);
+        given(eventGetResponseMock.location()).willReturn(location);
+        given(locationRepository.save(any(Location.class))).willThrow(new IllegalArgumentException("위치 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals("위치 저장 실패", e.getMessage());
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository).save(any(Time.class));
+        verify(locationRepository).save(any(Location.class));
+        verify(eventRepository, times(0)).save(any(Event.class));
+    }
+
+    @Test
+    void saveEventTest_EventSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
+        PersonalCalendar personalCalendar = new PersonalCalendar(null);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        LocationGetResponse location = new LocationGetResponse(null, "test", "test", 30.0, 32.2);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(eventGetResponseMock.time()).willReturn(time);
+        given(eventGetResponseMock.location()).willReturn(location);
+        given(eventRepository.save(any(Event.class))).willThrow(new IllegalArgumentException("일정 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "일정 저장 실패");
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository).save(any(Time.class));
+        verify(locationRepository).save(any(Location.class));
+        verify(eventRepository).save(any(Event.class));
+    }
+
+    @Test
+    void saveCreatedEventTest_EventSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        String eventId = "testId";
+        EventCreateRequest eventCreateRequestMock = mock(EventCreateRequest.class);
+        PersonalCalendar personalCalendar = new PersonalCalendar(null);
+        TimeCreateRequest time = new TimeCreateRequest("2024-10-01T00:00:00Z",
+            "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+
+        // Mock
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(
+            personalCalendar);
+        given(eventCreateRequestMock.time()).willReturn(time);
+        given(eventRepository.save(any(Event.class))).willThrow(new IllegalArgumentException("일정 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "일정 저장 실패");
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository).save(any(Time.class));
+        verify(eventRepository).save(any(Event.class));
+    }
+
+    @Test
+    void saveEventTest_ReminderSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
+        PersonalCalendar personalCalendar = new PersonalCalendar(null);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(eventGetResponseMock.time()).willReturn(time);
+        given(eventGetResponseMock.reminders()).willReturn(List.of(5, 10));
+        given(reminderRepository.save(any(Reminder.class))).willThrow(new IllegalArgumentException("리마인더 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "리마인더 저장 실패");
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository).save(any(Time.class));
+        verify(locationRepository, times(0)).save(any(Location.class));
+        verify(eventRepository).save(any(Event.class));
+        verify(reminderRepository).save(any(Reminder.class));
+    }
+
+    @Test
+    void saveEventTest_TimeSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        EventGetResponse eventGetResponseMock = mock(EventGetResponse.class);
+        PersonalCalendar personalCalendar = new PersonalCalendar(null);
+        TimeGetResponse time = new TimeGetResponse("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(eventGetResponseMock.time()).willReturn(time);
+        given(timeRepository.save(any(Time.class))).willThrow(new IllegalArgumentException("시간 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveEvent(eventGetResponseMock, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals("시간 저장 실패", e.getMessage());
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository).save(any(Time.class));
+        verify(eventRepository, times(0)).save(any(Event.class));
+    }
+
+    @Test
+    void saveCreatedEventTest_TimeSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        String eventId = "testId";
+        EventCreateRequest eventCreateRequestMock = mock(EventCreateRequest.class);
+        PersonalCalendar personalCalendar = new PersonalCalendar(null);
+        TimeCreateRequest time = new TimeCreateRequest("2024-10-01T00:00:00Z", "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+
+        // Mocking
+        given(personalCalendarService.findOrCreatePersonalCalendar(memberId)).willReturn(personalCalendar);
+        given(eventCreateRequestMock.time()).willReturn(time);
+        given(timeRepository.save(any(Time.class))).willThrow(new IllegalArgumentException("시간 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> eventService.saveCreatedEvent(eventCreateRequestMock, eventId,memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals("시간 저장 실패", e.getMessage());
+        verify(personalCalendarService).findOrCreatePersonalCalendar(memberId);
+        verify(timeRepository).save(any(Time.class));
+        verify(eventRepository, times(0)).save(any(Event.class));
     }
 
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarServiceTest.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.calendar.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -10,7 +11,7 @@ import java.util.Optional;
 import org.cookieandkakao.babting.domain.calendar.entity.PersonalCalendar;
 import org.cookieandkakao.babting.domain.calendar.repository.PersonalCalendarRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
-import org.cookieandkakao.babting.domain.member.repository.MemberRepository;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -26,7 +27,7 @@ class PersonalCalendarServiceTest {
     private PersonalCalendarRepository personalCalendarRepository;
 
     @Mock
-    private MemberRepository memberRepository;
+    private MemberService memberService;
 
     // Mock 객체 초기화
     @BeforeEach
@@ -56,6 +57,7 @@ class PersonalCalendarServiceTest {
         verify(personalCalendarRepository, times(0)).save(any(PersonalCalendar.class));
         assertNotNull(personalCalendar);
         assertNotNull(personalCalendar.getMember());
+        assertEquals(member, personalCalendar.getMember());
     }
 
     @Test
@@ -68,7 +70,7 @@ class PersonalCalendarServiceTest {
         // Mocking
         given(personalCalendarRepository.findByMemberMemberId(memberId)).willReturn(
             Optional.empty());
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(memberService.findMember(memberId)).willReturn(member);
         given(personalCalendarRepository.save(any(PersonalCalendar.class))).willReturn(
             newPersonalCalendar);
 
@@ -78,10 +80,11 @@ class PersonalCalendarServiceTest {
 
         // Then
         verify(personalCalendarRepository).findByMemberMemberId(any(Long.class));
-        verify(memberRepository).findById(any(Long.class));
+        verify(memberService).findMember(any(Long.class));
         verify(personalCalendarRepository).save(any(PersonalCalendar.class));
         assertNotNull(personalCalendar);
         assertNotNull(personalCalendar.getMember());
+        assertEquals(member, personalCalendar.getMember());
     }
 
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarServiceTest.java
@@ -95,10 +95,12 @@ class PersonalCalendarServiceTest {
         Long memberId = 1L;
 
         // Mocking
-        given(memberService.findMember(memberId)).willThrow(new MemberNotFoundException("멤버 찾을 수 없음"));
+        given(memberService.findMember(memberId)).willThrow(
+            new MemberNotFoundException("멤버 찾을 수 없음"));
 
         // When
-        Exception e = assertThrows(MemberNotFoundException.class, () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
+        Exception e = assertThrows(MemberNotFoundException.class,
+            () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
 
         // Then
         assertEquals(e.getClass(), MemberNotFoundException.class);
@@ -118,10 +120,12 @@ class PersonalCalendarServiceTest {
         given(personalCalendarRepository.findByMemberMemberId(memberId)).willReturn(
             Optional.empty());
         given(memberService.findMember(memberId)).willReturn(member);
-        given(personalCalendarRepository.save(any(PersonalCalendar.class))).willThrow(new IllegalArgumentException("개인 캘린더 저장 실패"));
+        given(personalCalendarRepository.save(any(PersonalCalendar.class))).willThrow(
+            new IllegalArgumentException("개인 캘린더 저장 실패"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -137,10 +141,12 @@ class PersonalCalendarServiceTest {
         Long memberId = 1L;
 
         // Mocking
-        given(personalCalendarRepository.findByMemberMemberId(memberId)).willThrow(new IllegalArgumentException("멤버 id로 찾을 수 없음"));
+        given(personalCalendarRepository.findByMemberMemberId(memberId)).willThrow(
+            new IllegalArgumentException("멤버 id로 찾을 수 없음"));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/PersonalCalendarServiceTest.java
@@ -2,12 +2,14 @@ package org.cookieandkakao.babting.domain.calendar.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
+import org.cookieandkakao.babting.common.exception.customexception.MemberNotFoundException;
 import org.cookieandkakao.babting.domain.calendar.entity.PersonalCalendar;
 import org.cookieandkakao.babting.domain.calendar.repository.PersonalCalendarRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
@@ -87,4 +89,64 @@ class PersonalCalendarServiceTest {
         assertEquals(member, personalCalendar.getMember());
     }
 
+    @Test
+    void findOrCreatePersonalCalendarTest_NotFoundMember() {
+        // Given
+        Long memberId = 1L;
+
+        // Mocking
+        given(memberService.findMember(memberId)).willThrow(new MemberNotFoundException("멤버 찾을 수 없음"));
+
+        // When
+        Exception e = assertThrows(MemberNotFoundException.class, () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
+
+        // Then
+        assertEquals(e.getClass(), MemberNotFoundException.class);
+        assertEquals(e.getMessage(), "멤버 찾을 수 없음");
+        verify(personalCalendarRepository).findByMemberMemberId(any(Long.class));
+        verify(memberService).findMember(any(Long.class));
+        verify(personalCalendarRepository, times(0)).save(any(PersonalCalendar.class));
+    }
+
+    @Test
+    void findOrCreatePersonalCalendarTest_PersonalCalendarSaveFailed() {
+        // Given
+        Long memberId = 1L;
+        Member member = new Member(memberId);
+
+        // Mocking
+        given(personalCalendarRepository.findByMemberMemberId(memberId)).willReturn(
+            Optional.empty());
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(personalCalendarRepository.save(any(PersonalCalendar.class))).willThrow(new IllegalArgumentException("개인 캘린더 저장 실패"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "개인 캘린더 저장 실패");
+        verify(personalCalendarRepository).findByMemberMemberId(any(Long.class));
+        verify(memberService).findMember(any(Long.class));
+        verify(personalCalendarRepository).save(any(PersonalCalendar.class));
+    }
+
+    @Test
+    void findOrCreatePersonalCalendarTest_ErrorFindByMemberMemberId() {
+        // Given
+        Long memberId = 1L;
+
+        // Mocking
+        given(personalCalendarRepository.findByMemberMemberId(memberId)).willThrow(new IllegalArgumentException("멤버 id로 찾을 수 없음"));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> personalCalendarService.findOrCreatePersonalCalendar(memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "멤버 id로 찾을 수 없음");
+        verify(personalCalendarRepository).findByMemberMemberId(any(Long.class));
+        verify(memberService, times(0)).findMember(any(Long.class));
+        verify(personalCalendarRepository, times(0)).save(any(PersonalCalendar.class));
+    }
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarClientServiceTest.java
@@ -1,109 +1,349 @@
 package org.cookieandkakao.babting.domain.calendar.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
-
+import java.util.function.Function;
+import org.cookieandkakao.babting.common.exception.customexception.ApiException;
 import org.cookieandkakao.babting.common.properties.KakaoProviderProperties;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventDetailGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventListGetResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.RequestBodySpec;
 import org.springframework.web.client.RestClient.RequestBodyUriSpec;
 import org.springframework.web.client.RestClient.RequestHeadersUriSpec;
 import org.springframework.web.client.RestClient.ResponseSpec;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
 
-@RestClientTest(KakaoProviderProperties.class)
+
+@ExtendWith(MockitoExtension.class)
 class TalkCalendarClientServiceTest {
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private KakaoProviderProperties kakaoProviderProperties;
 
     @InjectMocks
     private TalkCalendarClientService talkCalendarClientService;
 
     @Mock
-    private KakaoProviderProperties kakaoProviderProperties;
+    private RequestBodyUriSpec requestBodyUriSpec;
 
     @Mock
-    private RestClient restClient;
-
-    private RequestBodyUriSpec requestBodyUriSpec;
     private ResponseSpec responseSpec;
+
+    @Mock
+    private RequestBodySpec requestBodySpec;
+
+    @Mock
     private RequestHeadersUriSpec requestHeadersUriSpec;
 
-    private static MockedStatic<ResponseEntity> responseMockedStatic;
+    private static final String ACCESS_TOKEN = "testAccessToken";
+    private static final String EVENT_ID = "testId";
 
-    @BeforeAll
-    public static void beforeAll() {
-        responseMockedStatic = mockStatic(ResponseEntity.class);
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        responseMockedStatic.close();
-    }
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        requestBodyUriSpec = mock(RequestBodyUriSpec.class);
-        responseSpec = mock(ResponseSpec.class);
-        requestHeadersUriSpec = mock(RequestHeadersUriSpec.class);
-    }
 
     @Test
     void getEventListTest() {
         // Given
-        String accessToken = "testAccessToken";
-        String from = "2024-10-01T00:00:00Z";
-        String to = "2024-10-31T23:59:59Z";
-        String url = "https://kapi.kakao.com/v2/api/calendar/events";
-        URI uri = buildUri(url, from, to);
-
-        EventGetResponse eventGetResponse = new EventGetResponse("testId", "Test Title",
-            "USER", "calendarId", null, false, false, null, null,
-            "Test Description", null, null, "TestColor", null);
-        EventListGetResponse eventListGetResponseMock = new EventListGetResponse(
-            new ArrayList<>(List.of(eventGetResponse)));
+        String relativeUrl = "test";
+        String from = "test From";
+        String to = "test To";
+        EventGetResponse eventGetResponse = new EventGetResponse("testId", "test title", "USER",
+            null, null, false, false, null, null, "test description", null, null, null, null);
+        EventListGetResponse eventListGetResponse = new EventListGetResponse(
+            List.of(eventGetResponse));
+        ResponseEntity<EventListGetResponse> responseEntity = new ResponseEntity<>(
+            eventListGetResponse,
+            HttpStatus.OK);
 
         // Mocking
-        when(restClient.get()).thenReturn(requestHeadersUriSpec);
-        when(requestHeadersUriSpec.uri(any(URI.class))).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.header(anyString(), anyString())).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
-        responseMockedStatic.when(() -> ResponseEntity.ok(any(EventListGetResponse.class))).thenReturn(ResponseEntity.ok(eventListGetResponseMock));
-        when(responseSpec.toEntity(EventListGetResponse.class)).thenReturn(ResponseEntity.ok(eventListGetResponseMock));
+        given(kakaoProviderProperties.calendarEventListUri()).willReturn(relativeUrl);
+        given(restClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(any(Function.class))).will(invocationOnMock -> {
+            Function<UriBuilder, URI> uriFunction = invocationOnMock.getArgument(0);
+            URI uri = uriFunction.apply(UriComponentsBuilder.fromPath(relativeUrl));
+            return requestHeadersUriSpec;
+        });
+        given(requestHeadersUriSpec.header(anyString(), anyString())).willReturn(
+            requestBodyUriSpec);
+        given(requestBodyUriSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.toEntity(EventListGetResponse.class)).willReturn(responseEntity);
 
         // When
-        EventListGetResponse result = talkCalendarClientService.getEventList(accessToken, from, to);
+        EventListGetResponse result = talkCalendarClientService.getEventList(ACCESS_TOKEN, from,
+            to);
 
         // Then
         assertNotNull(result);
-        assertEquals(eventGetResponse.id(), result.events().get(0).id());
-
-        // Verify
+        assertEquals(result, eventListGetResponse);
         verify(restClient).get();
-        verify(requestHeadersUriSpec).uri(uri);
-        verify(requestBodyUriSpec).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        verify(requestHeadersUriSpec).uri(any(Function.class));
+        verify(requestHeadersUriSpec).header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN);
         verify(requestBodyUriSpec).retrieve();
         verify(responseSpec).toEntity(EventListGetResponse.class);
     }
 
-    private URI buildUri(String baseUrl, String from, String to) {
-        return URI.create(
-            String.format("%s?from=%s&to=%s&limit=100&time_zone=Asia/Seoul", baseUrl, from, to));
+    @Test
+    void getEventTest() {
+        // Given
+        String relativeUrl = "test";
+        EventGetResponse eventGetResponse = new EventGetResponse("testId", "test title", "USER",
+            null, null, false, false, null, null, "test description", null, null, null, null);
+        EventDetailGetResponse eventDetailGetResponse = new EventDetailGetResponse(
+            eventGetResponse);
+        ResponseEntity<EventDetailGetResponse> responseEntity = new ResponseEntity<>(
+            eventDetailGetResponse,
+            HttpStatus.OK);
+
+        // Mocking
+        given(kakaoProviderProperties.calendarEventDetailUri()).willReturn(relativeUrl);
+        given(restClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(any(Function.class))).will(invocationOnMock -> {
+            Function<UriBuilder, URI> uriFunction = invocationOnMock.getArgument(0);
+            URI uri = uriFunction.apply(UriComponentsBuilder.fromPath(relativeUrl));
+            return requestHeadersUriSpec;
+        });
+        given(requestHeadersUriSpec.header(anyString(), anyString())).willReturn(
+            requestBodyUriSpec);
+        given(requestBodyUriSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.toEntity(EventDetailGetResponse.class)).willReturn(responseEntity);
+
+        // When
+        EventDetailGetResponse result = talkCalendarClientService.getEvent(ACCESS_TOKEN, EVENT_ID);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result, eventDetailGetResponse);
+        assertEquals(result.event().id(), "testId");
+        verify(restClient).get();
+        verify(requestHeadersUriSpec).uri(any(Function.class));
+        verify(requestHeadersUriSpec).header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN);
+        verify(requestBodyUriSpec).retrieve();
+        verify(responseSpec).toEntity(EventDetailGetResponse.class);
+    }
+
+    @Test
+    void createEventTest() {
+        // Given
+        String relativeUrl = "test";
+        EventCreateResponse eventCreateResponse = new EventCreateResponse("testId");
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        ResponseEntity<EventCreateResponse> responseEntity = new ResponseEntity<>(
+            eventCreateResponse,
+            HttpStatus.CREATED);
+
+        // Mocking
+        given(kakaoProviderProperties.calendarCreateEventUri()).willReturn(relativeUrl);
+        given(restClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.header(anyString(), anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.header(anyString(), anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.body(any(MultiValueMap.class))).willReturn(requestBodySpec);
+        given(requestBodySpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.toEntity(EventCreateResponse.class)).willReturn(responseEntity);
+
+        // When
+        EventCreateResponse result = talkCalendarClientService.createEvent(ACCESS_TOKEN, formData);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(result, eventCreateResponse);
+        assertEquals(result.eventId(), "testId");
+        verify(restClient).post();
+        verify(requestBodyUriSpec).uri(relativeUrl);
+        verify(requestBodySpec).header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN);
+        verify(requestBodySpec).header(HttpHeaders.CONTENT_TYPE,
+            "application/x-www-form-urlencoded");
+        verify(requestBodySpec).body(formData);
+        verify(requestBodySpec).retrieve();
+        verify(responseSpec).toEntity(EventCreateResponse.class);
+    }
+
+    @Test
+    void getEventListTest_RestClientException() {
+        // Given
+        String relativeUrl = "test";
+        String from = "test From";
+        String to = "test To";
+
+        // Mocking
+        given(kakaoProviderProperties.calendarEventListUri()).willReturn(relativeUrl);
+        given(restClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(any(Function.class))).will(invocationOnMock -> {
+            Function<UriBuilder, URI> uriFunction = invocationOnMock.getArgument(0);
+            URI uri = uriFunction.apply(UriComponentsBuilder.fromPath(relativeUrl));
+            return requestHeadersUriSpec;
+        });
+        given(requestHeadersUriSpec.header(anyString(), anyString())).willReturn(
+            requestBodyUriSpec);
+        given(requestBodyUriSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.toEntity(EventListGetResponse.class)).willThrow(
+            new RestClientException("API 에러"));
+
+        // When
+        Exception e = assertThrows(
+            ApiException.class,
+            () -> talkCalendarClientService.getEventList(ACCESS_TOKEN, from, to));
+
+        // Then
+        assertNotNull(e);
+        assertEquals(e.getClass(), ApiException.class);
+        assertEquals(e.getMessage(), "일정 목록 조회 중 에러 발생 : API 에러");
+        verify(kakaoProviderProperties).calendarEventListUri();
+        verify(restClient).get();
+        verify(requestHeadersUriSpec).uri(any(Function.class));
+        verify(requestHeadersUriSpec).header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN);
+        verify(requestBodyUriSpec).retrieve();
+        verify(responseSpec).toEntity(EventListGetResponse.class);
+    }
+
+    @Test
+    void getEventTest_RestClientException() {
+        // Given
+        String relativeUrl = "test";
+
+        // Mocking
+        given(kakaoProviderProperties.calendarEventDetailUri()).willReturn(relativeUrl);
+        given(restClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(any(Function.class))).will(invocationOnMock -> {
+            Function<UriBuilder, URI> uriFunction = invocationOnMock.getArgument(0);
+            URI uri = uriFunction.apply(UriComponentsBuilder.fromPath(relativeUrl));
+            return requestHeadersUriSpec;
+        });
+        given(requestHeadersUriSpec.header(anyString(), anyString())).willReturn(
+            requestBodyUriSpec);
+        given(requestBodyUriSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.toEntity(EventDetailGetResponse.class)).willThrow(
+            new RestClientException("API 에러"));
+
+        // When
+        Exception e = assertThrows(
+            ApiException.class, () -> talkCalendarClientService.getEvent(ACCESS_TOKEN, EVENT_ID)
+        );
+
+        // Then
+        assertNotNull(e);
+        assertEquals(e.getClass(), ApiException.class);
+        assertEquals(e.getMessage(), "일정 상세 조회 중 오류 발생 : API 에러");
+        verify(kakaoProviderProperties).calendarEventDetailUri();
+        verify(restClient).get();
+        verify(requestHeadersUriSpec).uri(any(Function.class));
+        verify(requestHeadersUriSpec).header(anyString(), anyString());
+        verify(requestBodyUriSpec).retrieve();
+        verify(responseSpec).toEntity(EventDetailGetResponse.class);
+    }
+
+    @Test
+    void createEventTest_RestClientException() {
+        // Given
+        String relativeUrl = "test";
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+
+        // Mocking
+        given(kakaoProviderProperties.calendarCreateEventUri()).willReturn(relativeUrl);
+        given(restClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.header(anyString(), anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.header(anyString(), anyString())).willReturn(requestBodySpec);
+        given(requestBodySpec.body(any(MultiValueMap.class))).willReturn(requestBodySpec);
+        given(requestBodySpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.toEntity(EventCreateResponse.class)).willThrow(
+            new RestClientException("API 에러"));
+
+        // When
+        Exception e = assertThrows(
+            ApiException.class, () -> talkCalendarClientService.createEvent(ACCESS_TOKEN, formData)
+        );
+
+        // Then
+        assertNotNull(e);
+        assertEquals(e.getClass(), ApiException.class);
+        assertEquals(e.getMessage(), "일정 생성 중 오류 발생 : API 에러");
+        verify(kakaoProviderProperties).calendarCreateEventUri();
+        verify(restClient).post();
+        verify(requestBodyUriSpec).uri(anyString());
+        verify(requestBodySpec, times(2)).header(anyString(), anyString());
+        verify(requestBodySpec).body(any(MultiValueMap.class));
+        verify(requestBodySpec).retrieve();
+        verify(responseSpec).toEntity(EventCreateResponse.class);
+    }
+
+    @Test
+    void getEventListTest_알수없는_예외_발생시_예외처리() {
+        // Given
+        String from = "2024-01-01";
+        String to = "2024-01-10";
+
+        // Mocking
+        given(restClient.get()).willThrow(new RuntimeException("API 에러"));
+
+        // When
+        Exception e = assertThrows(RuntimeException.class,
+            () -> talkCalendarClientService.getEventList(ACCESS_TOKEN, from, to));
+
+        // Then
+        assertNotNull(e);
+        assertEquals(e.getClass(), RuntimeException.class);
+        assertEquals(e.getMessage(), "API 에러");
+        verify(restClient).get();
+    }
+
+    @Test
+    void getEventTest_알수없는_예외_발생시_예외처리() {
+        // Mocking
+        given(restClient.get()).willThrow(new RuntimeException("API 에러"));
+
+        // When
+        Exception e = assertThrows(RuntimeException.class,
+            () -> talkCalendarClientService.getEvent(ACCESS_TOKEN, EVENT_ID));
+
+        // Then
+        assertNotNull(e);
+        assertEquals(e.getClass(), RuntimeException.class);
+        assertEquals(e.getMessage(), "API 에러");
+        verify(restClient).get();
+    }
+
+    @Test
+    void createEventTest_알수없는_예외_발생시_예외처리() {
+        // Given
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+
+        // Mocking
+        given(restClient.post()).willThrow(new RuntimeException("API 에러"));
+
+        // When
+        Exception e = assertThrows(RuntimeException.class,
+            () -> talkCalendarClientService.createEvent(ACCESS_TOKEN, formData));
+
+        // Then
+        assertNotNull(e);
+        assertEquals(e.getClass(), RuntimeException.class);
+        assertEquals(e.getMessage(), "API 에러");
+        verify(restClient).post();
     }
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarServiceTest.java
@@ -2,16 +2,17 @@ package org.cookieandkakao.babting.domain.calendar.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import org.cookieandkakao.babting.common.exception.customexception.EventCreationException;
 import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
 import org.cookieandkakao.babting.domain.calendar.dto.request.TimeCreateRequest;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
@@ -114,20 +115,19 @@ class TalkCalendarServiceTest {
     }
 
     @Test
-    void createEventTest() {
+    void createEventTest() throws JsonProcessingException {
         // Given
         Long memberId = 1L;
         TimeCreateRequest timeRequest = new TimeCreateRequest("2024-10-01T00:00:00Z",
             "2024-10-01T03:00:00Z", "Asia/Seoul", false);
         EventCreateRequest eventCreateRequest = new EventCreateRequest("testTitle", timeRequest,
-            null, null);
+            null, null, null);
         String accessToken = "testAccessToken";
         String eventId = "testEventId";
-        String eventJson = convertToJSONString(eventCreateRequest);
+        String eventJson = objectMapper.writeValueAsString(eventCreateRequest);
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("event", eventJson);
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("event_id", eventId);
+        EventCreateResponse responseBody = new EventCreateResponse(eventId);
 
         // Mocking
         given(memberService.getKakaoToken(memberId)).willReturn(
@@ -145,12 +145,197 @@ class TalkCalendarServiceTest {
         assertEquals(eventId, result.eventId());
     }
 
-    private String convertToJSONString(EventCreateRequest eventCreateRequest) {
-        try {
-            return objectMapper.writeValueAsString(eventCreateRequest);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+    @Test
+    void getEventTest_InvalidMemberId() {
+        // Given
+        Long memberId = null;
+        String eventId = "testId";
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willThrow(
+            new IllegalArgumentException("존재하지 않는 MemberID입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.getEvent(memberId, eventId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "존재하지 않는 MemberID입니다.");
+        verify(memberService).getKakaoToken(memberId);
+    }
+
+    @Test
+    void getEventTest_InvalidEventId() {
+        // Given
+        Long memberId = 1L;
+        String eventId = null;
+        String accessToken = "testAccessToken";
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willReturn(
+            new KakaoToken(accessToken, null, null, null));
+        given(talkCalendarClientService.getEvent(accessToken, eventId)).willThrow(
+            new IllegalArgumentException("존재하지 않는 EventID입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.getEvent(memberId, eventId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "존재하지 않는 EventID입니다.");
+        verify(memberService).getKakaoToken(memberId);
+        verify(talkCalendarClientService).getEvent(accessToken, eventId);
+    }
+
+    @Test
+    void getUpdatedEventListTest_InvalidMemberId() {
+        // Given
+        Long memberId = null;
+        String from = "2024-10-01T00:00:00Z";
+        String to = "2024-10-31T23:59:59Z";
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willThrow(new IllegalArgumentException("존재하지 않는 MemberID입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "존재하지 않는 MemberID입니다.");
+        verify(memberService).getKakaoToken(memberId);
+    }
+
+    @Test
+    void getUpdatedEventListTest_InvalidFrom() {
+        // Given
+        Long memberId = 1L;
+        String from = null;
+        String to = "2024-10-31T23:59:59Z";
+        String accessToken = "testAccessToken";
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willReturn(
+            new KakaoToken(accessToken, null, null, null));
+        given(talkCalendarClientService.getEventList(accessToken, from, to)).willThrow(
+            new IllegalArgumentException("잘못된 From 값 입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "잘못된 From 값 입니다.");
+        verify(memberService).getKakaoToken(any(Long.class));
+        verify(talkCalendarClientService).getEventList(accessToken, from, to);
+    }
+
+    @Test
+    void getUpdatedEventListTest_InvalidTo() {
+        // Given
+        Long memberId = 1L;
+        String from = "2024-10-01T00:00:00Z";
+        String to = null;
+        String accessToken = "testAccessToken";
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willReturn(
+            new KakaoToken(accessToken, null, null, null));
+        given(talkCalendarClientService.getEventList(accessToken, from, to)).willThrow(
+            new IllegalArgumentException("잘못된 To 값 입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "잘못된 To 값 입니다.");
+        verify(memberService).getKakaoToken(any(Long.class));
+        verify(talkCalendarClientService).getEventList(accessToken, from, to);
+    }
+
+    @Test
+    void getUpdatedEventListTest_InvalidEventId() {
+        // Given
+        Long memberId = 1L;
+        String from = "2024-10-01T00:00:00Z";
+        String to = "2024-10-31T23:59:59Z";
+        EventGetResponse eventGetResponse = new EventGetResponse("testId", "Test Title",
+            "USER", "calendarId", null, false, false, null, null,
+            "Test Description", null, null, "TestColor", null);
+        EventListGetResponse eventListGetResponse = new EventListGetResponse(
+            new ArrayList<>(List.of((eventGetResponse))));
+        String accessToken = "testAccessToken";
+        EventDetailGetResponse eventDetailGetResponseMock = new EventDetailGetResponse(
+            eventGetResponse);
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willReturn(
+            new KakaoToken(accessToken, null, null, null));
+        given(talkCalendarClientService.getEventList(accessToken, from, to)).willReturn(
+            eventListGetResponse);
+        given(talkCalendarClientService.getEvent(accessToken, eventGetResponse.id())).willThrow(new IllegalArgumentException("존재하지 않는 EventID입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "존재하지 않는 EventID입니다.");
+        verify(memberService).getKakaoToken(any(Long.class));
+        verify(talkCalendarClientService).getEventList(accessToken, from, to);
+        verify(talkCalendarClientService).getEvent(accessToken, eventGetResponse.id());
+    }
+
+    @Test
+    void createEventTest_InvalidEventCreateRequest() throws JsonProcessingException {
+        Long memberId = 1L;
+        TimeCreateRequest timeRequest = new TimeCreateRequest("2024-10-01T00:00:00Z",
+            "2024-10-01T03:00:00Z", "Asia/Seoul", false);
+        EventCreateRequest eventCreateRequest = null;
+        String accessToken = "testAccessToken";
+        String eventId = "testEventId";
+        String eventJson = objectMapper.writeValueAsString(eventCreateRequest);
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("event", eventJson);
+        EventCreateResponse responseBody = new EventCreateResponse(eventId);
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willReturn(
+            new KakaoToken(accessToken, null, null, null));
+        given(talkCalendarClientService.createEvent(accessToken, formData)).willThrow(
+            new EventCreationException("EventCreateRequest 에러"));
+
+        // When
+        Exception e = assertThrows(EventCreationException.class, () -> talkCalendarService.createEvent(eventCreateRequest, memberId));
+
+        // Then
+        assertEquals(e.getClass(),EventCreationException.class);
+        assertEquals(e.getMessage(), "EventCreateRequest 에러");
+        verify(memberService).getKakaoToken(memberId);
+        verify(talkCalendarClientService).createEvent(accessToken, formData);
+    }
+
+    @Test
+    void createEventTest_InvalidMemberId() {
+        // Given
+        Long memberId = 1L;
+        EventCreateRequest eventCreateRequestMcok = mock(EventCreateRequest.class);
+
+        // Mocking
+        given(memberService.getKakaoToken(memberId)).willThrow(new IllegalArgumentException("존재하지 않는 MemberID입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class, () -> talkCalendarService.createEvent(eventCreateRequestMcok, memberId));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "존재하지 않는 MemberID입니다.");
+        verify(memberService).getKakaoToken(memberId);
     }
 
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarServiceTest.java
@@ -197,10 +197,12 @@ class TalkCalendarServiceTest {
         String to = "2024-10-31T23:59:59Z";
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willThrow(new IllegalArgumentException("존재하지 않는 MemberID입니다."));
+        given(memberService.getKakaoToken(memberId)).willThrow(
+            new IllegalArgumentException("존재하지 않는 MemberID입니다."));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -278,10 +280,12 @@ class TalkCalendarServiceTest {
             new KakaoToken(accessToken, null, null, null));
         given(talkCalendarClientService.getEventList(accessToken, from, to)).willReturn(
             eventListGetResponse);
-        given(talkCalendarClientService.getEvent(accessToken, eventGetResponse.id())).willThrow(new IllegalArgumentException("존재하지 않는 EventID입니다."));
+        given(talkCalendarClientService.getEvent(accessToken, eventGetResponse.id())).willThrow(
+            new IllegalArgumentException("존재하지 않는 EventID입니다."));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.getUpdatedEventList(from, to, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
@@ -311,10 +315,11 @@ class TalkCalendarServiceTest {
             new EventCreationException("EventCreateRequest 에러"));
 
         // When
-        Exception e = assertThrows(EventCreationException.class, () -> talkCalendarService.createEvent(eventCreateRequest, memberId));
+        Exception e = assertThrows(EventCreationException.class,
+            () -> talkCalendarService.createEvent(eventCreateRequest, memberId));
 
         // Then
-        assertEquals(e.getClass(),EventCreationException.class);
+        assertEquals(e.getClass(), EventCreationException.class);
         assertEquals(e.getMessage(), "EventCreateRequest 에러");
         verify(memberService).getKakaoToken(memberId);
         verify(talkCalendarClientService).createEvent(accessToken, formData);
@@ -327,10 +332,12 @@ class TalkCalendarServiceTest {
         EventCreateRequest eventCreateRequestMcok = mock(EventCreateRequest.class);
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willThrow(new IllegalArgumentException("존재하지 않는 MemberID입니다."));
+        given(memberService.getKakaoToken(memberId)).willThrow(
+            new IllegalArgumentException("존재하지 않는 MemberID입니다."));
 
         // When
-        Exception e = assertThrows(IllegalArgumentException.class, () -> talkCalendarService.createEvent(eventCreateRequestMcok, memberId));
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> talkCalendarService.createEvent(eventCreateRequestMcok, memberId));
 
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);


### PR DESCRIPTION
## 주요 변경사항
코드 리뷰 및 멘토링 내용 반영
테스트 코드 추가 및 수정
모임 확정 시 캘린더에 일정 추가 부분 수정
캐시 사용 부분 수정 ( CacheManager -> RedisTemplate)

## 리뷰어에게...
코드 리뷰와 멘토링 때 알려주셨던 부분을 반영했습니다. 추가로 저번과 다르게 모임 확정할 때 시간을 requestBody로 받아 처리하도록 수정하였습니다. 
테스트 코드도 Controller까지 작성했습니다. Controller는 현재 정상적인 케이스만 작성되었습니다. 찾아보니 Controller에서는 mockMVC를 사용한다고 하는데 그 부분을 더 찾아보고 적용하겠습니다! 지금은 ServiceTest에 사용했던 것처럼 ControllerTest를 작성해두었습니다.
캐시에서 키 값이  memberId만 사용하고 있어 from이랑 to가 달라도 memberId만 같으면 같은 값을 반환하므로 수정했습니다. CacheManger를 사용하면 `@Cacheable`, `@CacheEvict` 같은 어노테이션으로 캐시를 간편하게 사용할 수 있습니다. RedisTemplate는 캐시 저장, 조회, 삭제가 코드에 명시적으로 작성되므로 제어가 더 세밀하지만, 코드가 더 복잡해질 수 있습니다. 하지만 제가 원하는 기능을 구현하기에는 RedisTemplate가 적합한 것 같아 이걸로 수정했습니다.

### 궁금한 점
프론트 요청이랑 관계 없이 톡캘린더 api 요청 날릴 땐 한 달 단위로 가져다 놓고 거기서 프론트에서 요청한 부분만 골라서 사용하는 것에 대해 어떻게 생각하시는지 궁금합니다.

## 관련 이슈

closes #

## 체크리스트

- [X] `reviewers` 설정
- [X] `label` 설정
