### PR TITLE
[FEAT] 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/common/properties/KakaoProviderProperties.java
+++ b/src/main/java/org/cookieandkakao/babting/common/properties/KakaoProviderProperties.java
@@ -7,6 +7,7 @@ public record KakaoProviderProperties(
     String authorizationUri,
     String tokenUri,
     String userInfoUri,
+    String unlinkUri,
     String calendarEventListUri,
     String calendarEventDetailUri,
     String calendarCreateEventUri

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import org.cookieandkakao.babting.domain.member.dto.MemberProfileGetResponse;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +27,12 @@ public class MemberController {
         @LoginMemberId Long memberId) {
         MemberProfileGetResponse memberProfile = memberService.getMemberProfile(memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "프로필 조회 성공", memberProfile);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponseBody.SuccessBody<Void>> deleteMember(
+        @LoginMemberId Long memberId) {
+        memberService.deleteMember(memberId);
+        return ApiResponseGenerator.success(HttpStatus.OK, "회원 탈퇴 성공");
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/entity/Member.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.member.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,7 +31,7 @@ public class Member {
     @Column
     private String profileImageUrl;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "kako_token_id")
     private KakaoToken kakaoToken;
 

--- a/src/main/java/org/cookieandkakao/babting/domain/member/entity/Member.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/entity/Member.java
@@ -31,7 +31,7 @@ public class Member {
     @Column
     private String profileImageUrl;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "kako_token_id")
     private KakaoToken kakaoToken;
 

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
@@ -96,6 +96,22 @@ public class AuthService {
         return entity.getBody();
     }
 
+    public void unlinkMember(String accessToken) {
+
+        String unlinkUri = kakaoProviderProperties.unlinkUri();
+
+        restClient.get()
+            .uri(unlinkUri)
+            .header("Authorization", "Bearer " + accessToken)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                throw new IllegalArgumentException("카카오 연결 끊기 실패");
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                throw new RuntimeException("카카오 인증 서버 에러");
+            });
+    }
+
     @Transactional
     public void saveMemberInfoAndKakaoToken(
         KakaoMemberInfoGetResponse kakaoMemberInfoGetResponse,

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.member.service;
 
+import jakarta.transaction.Transactional;
 import org.cookieandkakao.babting.domain.member.dto.MemberProfileGetResponse;
 import org.cookieandkakao.babting.domain.member.entity.KakaoToken;
 import org.cookieandkakao.babting.domain.member.entity.Member;
@@ -12,9 +13,11 @@ import java.util.NoSuchElementException;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final AuthService authService;
 
-    public MemberService(MemberRepository memberRepository) {
+    public MemberService(MemberRepository memberRepository, AuthService authService) {
         this.memberRepository = memberRepository;
+        this.authService = authService;
     }
 
     public MemberProfileGetResponse getMemberProfile(Long memberId) {
@@ -26,6 +29,15 @@ public class MemberService {
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new NoSuchElementException("해당 사용자가 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void deleteMember(Long memberId) {
+        String accessToken = getKakaoToken(memberId).getAccessToken();
+        authService.unlinkMember(accessToken);
+
+        memberRepository.deleteById(memberId);
+        // Todo: 해당 멤버와 관련된 entity들 삭제 로직 추가
     }
 
     public KakaoToken getKakaoToken(Long memberId) {


### PR DESCRIPTION
## 주요 변경사항
- 카카오 로그인시 Member를 저장할 때  KakaoToken entity가 먼저 저장되지 않아서 오류가 발생하는걸 확인하고 Member entity에 cascadeType을 ALL로 설정하여 해결했습니다.
- 회원 탈퇴 기능을 구현했습니다.

## 리뷰어에게...
시험이 다음주까지 있어서 프로젝트에 많이 시간을 쓰진 못했습니다.
RestClientConfig 부분은 충돌 날까봐 이번엔 수정 안했습니다. 보민님 pr 머지되면 수정하겠습니다.
테스트 코드 작성도 시험 끝나고 제대로 해보겠습니다.

## 관련 이슈

closes #

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
