### PR TITLE
[REFACTOR] 쿼리 최적화, 모임별 추천 음식 계산 로직 변경 등

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/GlobalExceptionHandler.java
@@ -3,8 +3,11 @@ import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.FailureBody
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
 import org.cookieandkakao.babting.common.exception.customexception.ApiException;
 import org.cookieandkakao.babting.common.exception.customexception.EventCreationException;
+import org.cookieandkakao.babting.common.exception.customexception.InvalidFoodPreferenceTypeException;
 import org.cookieandkakao.babting.common.exception.customexception.JsonConversionException;
 import org.cookieandkakao.babting.common.exception.customexception.MemberNotFoundException;
+import org.cookieandkakao.babting.common.exception.customexception.FoodNotFoundException;
+import org.cookieandkakao.babting.common.exception.customexception.PreferenceConflictException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -39,10 +42,24 @@ public class GlobalExceptionHandler {
         return ApiResponseGenerator.fail(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
+    @ExceptionHandler(JsonConversionException.class)
+    public ResponseEntity<FailureBody> handleFoodNotFoundException(FoodNotFoundException ex) {
+        return ApiResponseGenerator.fail(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(JsonConversionException.class)
+    public ResponseEntity<FailureBody> handlePreferenceConflictException(PreferenceConflictException ex) {
+        return ApiResponseGenerator.fail(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(JsonConversionException.class)
+    public ResponseEntity<FailureBody> handleInvalidFoodPreferenceTypeException(InvalidFoodPreferenceTypeException ex) {
+        return ApiResponseGenerator.fail(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
     // 모든 Exception을 처리하는 핸들러
     @ExceptionHandler(Exception.class)
     public ResponseEntity<FailureBody> handleAllExceptions(Exception ex) {
         return ApiResponseGenerator.fail(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
-
 }

--- a/src/main/java/org/cookieandkakao/babting/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/GlobalExceptionHandler.java
@@ -42,17 +42,17 @@ public class GlobalExceptionHandler {
         return ApiResponseGenerator.fail(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
-    @ExceptionHandler(JsonConversionException.class)
+    @ExceptionHandler(FoodNotFoundException.class)
     public ResponseEntity<FailureBody> handleFoodNotFoundException(FoodNotFoundException ex) {
         return ApiResponseGenerator.fail(HttpStatus.NOT_FOUND, ex.getMessage());
     }
 
-    @ExceptionHandler(JsonConversionException.class)
+    @ExceptionHandler(PreferenceConflictException.class)
     public ResponseEntity<FailureBody> handlePreferenceConflictException(PreferenceConflictException ex) {
         return ApiResponseGenerator.fail(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
-    @ExceptionHandler(JsonConversionException.class)
+    @ExceptionHandler(InvalidFoodPreferenceTypeException.class)
     public ResponseEntity<FailureBody> handleInvalidFoodPreferenceTypeException(InvalidFoodPreferenceTypeException ex) {
         return ApiResponseGenerator.fail(HttpStatus.NOT_FOUND, ex.getMessage());
     }

--- a/src/main/java/org/cookieandkakao/babting/common/exception/customexception/FoodNotFoundException.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/customexception/FoodNotFoundException.java
@@ -1,0 +1,7 @@
+package org.cookieandkakao.babting.common.exception.customexception;
+
+public class FoodNotFoundException extends RuntimeException {
+  public FoodNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/cookieandkakao/babting/common/exception/customexception/InvalidFoodPreferenceTypeException.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/customexception/InvalidFoodPreferenceTypeException.java
@@ -1,0 +1,7 @@
+package org.cookieandkakao.babting.common.exception.customexception;
+
+public class InvalidFoodPreferenceTypeException extends RuntimeException {
+  public InvalidFoodPreferenceTypeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/cookieandkakao/babting/common/exception/customexception/PreferenceConflictException.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/customexception/PreferenceConflictException.java
@@ -1,0 +1,7 @@
+package org.cookieandkakao.babting.common.exception.customexception;
+
+public class PreferenceConflictException extends RuntimeException {
+  public PreferenceConflictException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
@@ -38,7 +38,7 @@ public class FoodPreferenceController {
 
     // 선호/비선호 음식 조회
     @GetMapping("/{type}")
-    public ResponseEntity<SuccessBody<List<FoodPreferenceGetResponse>>> getFoodPreferences(
+    public ResponseEntity<?> getFoodPreferences(
             @PathVariable String type,
             @LoginMemberId Long memberId
     ) {
@@ -46,7 +46,7 @@ public class FoodPreferenceController {
         List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMember(memberId);
 
         if (preferences.isEmpty()) {
-            return ApiResponseGenerator.success(HttpStatus.OK, "조회된 음식이 없습니다", null);
+            return ApiResponseGenerator.fail(HttpStatus.OK, "조회된 음식이 없습니다");
         }
 
         return ApiResponseGenerator.success(HttpStatus.OK, "음식 조회 성공", preferences);

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
@@ -3,6 +3,7 @@ package org.cookieandkakao.babting.domain.food.controller;
 import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.SuccessBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
+import org.cookieandkakao.babting.common.exception.customexception.InvalidFoodPreferenceTypeException;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceCreateRequest;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.service.FoodPreferenceStrategy;
@@ -41,10 +42,7 @@ public class FoodPreferenceController {
             @PathVariable String type,
             @LoginMemberId Long memberId
     ) {
-        FoodPreferenceStrategy strategy = strategies.get(type);
-        if (strategy == null) {
-            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
-        }
+        FoodPreferenceStrategy strategy = getStrategy(type);
         List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMember(memberId);
 
         if (preferences.isEmpty()) {
@@ -61,10 +59,7 @@ public class FoodPreferenceController {
             @RequestBody FoodPreferenceCreateRequest request,
             @LoginMemberId Long memberId
     ) {
-        FoodPreferenceStrategy strategy = strategies.get(type);
-        if (strategy == null) {
-            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
-        }
+        FoodPreferenceStrategy strategy = getStrategy(type);
 
         FoodPreferenceGetResponse response = strategy.addPreference(request, memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "음식 추가 성공", response);
@@ -77,12 +72,17 @@ public class FoodPreferenceController {
             @RequestBody FoodPreferenceCreateRequest request,
             @LoginMemberId Long memberId
     ) {
-        FoodPreferenceStrategy strategy = strategies.get(type);
-        if (strategy == null) {
-            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
-        }
+        FoodPreferenceStrategy strategy = getStrategy(type);
 
         strategy.deletePreference(request.foodId(), memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "음식 삭제 성공");
+    }
+
+    private FoodPreferenceStrategy getStrategy(String type) {
+        FoodPreferenceStrategy strategy = strategies.get(type);
+        if (strategy == null) {
+            throw new InvalidFoodPreferenceTypeException("잘못된 선호 타입입니다");
+        }
+        return strategy;
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
@@ -41,7 +41,10 @@ public class FoodPreferenceController {
             @PathVariable String type,
             @LoginMemberId Long memberId
     ) {
-        FoodPreferenceStrategy strategy = getStrategy(type);
+        FoodPreferenceStrategy strategy = strategies.get(type);
+        if (strategy == null) {
+            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
+        }
         List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMember(memberId);
 
         if (preferences.isEmpty()) {
@@ -58,7 +61,10 @@ public class FoodPreferenceController {
             @RequestBody FoodPreferenceCreateRequest request,
             @LoginMemberId Long memberId
     ) {
-        FoodPreferenceStrategy strategy = getStrategy(type);
+        FoodPreferenceStrategy strategy = strategies.get(type);
+        if (strategy == null) {
+            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
+        }
 
         FoodPreferenceGetResponse response = strategy.addPreference(request, memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "음식 추가 성공", response);
@@ -71,17 +77,12 @@ public class FoodPreferenceController {
             @RequestBody FoodPreferenceCreateRequest request,
             @LoginMemberId Long memberId
     ) {
-        FoodPreferenceStrategy strategy = getStrategy(type);
+        FoodPreferenceStrategy strategy = strategies.get(type);
+        if (strategy == null) {
+            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
+        }
 
         strategy.deletePreference(request.foodId(), memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "음식 삭제 성공");
-    }
-
-    private FoodPreferenceStrategy getStrategy(String type) {
-        FoodPreferenceStrategy strategy = strategies.get(type);
-        if (strategy == null) {
-            throw new IllegalArgumentException("Invalid preference type");
-        }
-        return strategy;
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/FoodPreferenceController.java
@@ -45,7 +45,7 @@ public class FoodPreferenceController {
         List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMember(memberId);
 
         if (preferences.isEmpty()) {
-            return ApiResponseGenerator.success(HttpStatus.NO_CONTENT, "조회된 음식이 없습니다", null);
+            return ApiResponseGenerator.success(HttpStatus.OK, "조회된 음식이 없습니다", null);
         }
 
         return ApiResponseGenerator.success(HttpStatus.OK, "음식 조회 성공", preferences);

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
@@ -92,13 +92,12 @@ public class MemberMeetingFoodPreferenceController {
 
         Set<Long> recommendedFoodIds = meetingPreferenceService.getRecommendedFoodsForMeeting(meetingId);
 
-        List<FoodPreferenceGetResponse> recommendedFoods = recommendedFoodIds.stream()
-                .map(foodRepositoryService::findFoodById) // Food 엔티티 조회
-                .map(food -> new FoodPreferenceGetResponse(
-                        food.getFoodId(),
-                        food.getFoodCategory().getName(),
-                        food.getName()))
-                .collect(Collectors.toList());
+        List<FoodPreferenceGetResponse> recommendedFoods = foodRepositoryService.findFoodsByIds(recommendedFoodIds).stream()
+            .map(food -> new FoodPreferenceGetResponse(
+                food.getFoodId(),
+                food.getFoodCategory().getName(),
+                food.getName()))
+            .collect(Collectors.toList());
 
         return ApiResponseGenerator.success(HttpStatus.OK, "모임 추천 음식 조회 성공", recommendedFoods);
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
@@ -63,7 +63,7 @@ public class MemberMeetingFoodPreferenceController {
         List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMeeting(meetingId, memberId);
 
         if (preferences.isEmpty()) {
-            return ApiResponseGenerator.success(HttpStatus.NO_CONTENT, "조회된 음식이 없습니다", null);
+            return ApiResponseGenerator.success(HttpStatus.OK, "조회된 음식이 없습니다", null);
         }
 
         return ApiResponseGenerator.success(HttpStatus.OK, "모임별 개인 선호/비선호 음식 조회 성공", preferences);

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
@@ -57,7 +57,7 @@ public class MemberMeetingFoodPreferenceController {
     ) {
         MeetingFoodPreferenceStrategy strategy = strategies.get(type);
         if (strategy == null) {
-            throw new IllegalArgumentException("Invalid preference type");
+            return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
         }
 
         List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMeeting(meetingId, memberId);

--- a/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/controller/MemberMeetingFoodPreferenceController.java
@@ -3,6 +3,7 @@ package org.cookieandkakao.babting.domain.food.controller;
 import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
+import org.cookieandkakao.babting.common.exception.customexception.InvalidFoodPreferenceTypeException;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.dto.PersonalPreferenceUpdateRequest;
 import org.cookieandkakao.babting.domain.food.service.MeetingFoodPreferenceStrategy;
@@ -25,67 +26,67 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/meeting")
 public class MemberMeetingFoodPreferenceController {
-  private final Map<String, MeetingFoodPreferenceStrategy> strategies;
-  private final MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater;
-  private final MeetingPreferenceService meetingPreferenceService;
+    private final Map<String, MeetingFoodPreferenceStrategy> strategies;
+    private final MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater;
+    private final MeetingPreferenceService meetingPreferenceService;
 
-  public MemberMeetingFoodPreferenceController(
-      MeetingPreferenceFoodService meetingPreferenceFoodService,
-      MeetingNonPreferenceFoodService meetingNonPreferenceFoodService,
-      MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater,
-      MeetingPreferenceService meetingPreferenceService
-      ) {
-    this.meetingFoodPreferenceUpdater = meetingFoodPreferenceUpdater;
-    this.meetingPreferenceService = meetingPreferenceService;
-    strategies = Map.of(
-        "preferences", meetingPreferenceFoodService,
-        "non-preferences", meetingNonPreferenceFoodService
-    );
-  }
-
-  @GetMapping("/{meeting_id}/{type}")
-  public ResponseEntity<ApiResponseBody.SuccessBody<List<FoodPreferenceGetResponse>>> getFoodPreferences(
-      @PathVariable String type,
-      @LoginMemberId Long memberId,
-      @PathVariable("meeting_id") Long meetingId
-  ) {
-    MeetingFoodPreferenceStrategy strategy = strategies.get(type);
-    if (strategy == null) {
-      return ApiResponseGenerator.success(HttpStatus.NOT_FOUND, "잘못된 선호 타입입니다", null);
+    public MemberMeetingFoodPreferenceController(
+            MeetingPreferenceFoodService meetingPreferenceFoodService,
+            MeetingNonPreferenceFoodService meetingNonPreferenceFoodService,
+            MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater,
+            MeetingPreferenceService meetingPreferenceService
+    ) {
+        this.meetingFoodPreferenceUpdater = meetingFoodPreferenceUpdater;
+        this.meetingPreferenceService = meetingPreferenceService;
+        strategies = Map.of(
+                "preferences", meetingPreferenceFoodService,
+                "non-preferences", meetingNonPreferenceFoodService
+        );
     }
 
-    List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMeeting(meetingId, memberId);
+    @GetMapping("/{meeting_id}/{type}")
+    public ResponseEntity<ApiResponseBody.SuccessBody<List<FoodPreferenceGetResponse>>> getFoodPreferences(
+            @PathVariable String type,
+            @LoginMemberId Long memberId,
+            @PathVariable("meeting_id") Long meetingId
+    ) {
+        MeetingFoodPreferenceStrategy strategy = strategies.get(type);
+        if (strategy == null) {
+            throw new InvalidFoodPreferenceTypeException("잘못된 선호 타입입니다");
+        }
 
-    if (preferences.isEmpty()) {
-      return ApiResponseGenerator.success(HttpStatus.OK, "조회된 음식이 없습니다", null);
+        List<FoodPreferenceGetResponse> preferences = strategy.getAllPreferencesByMeeting(meetingId, memberId);
+
+        if (preferences.isEmpty()) {
+            return ApiResponseGenerator.success(HttpStatus.OK, "조회된 음식이 없습니다", null);
+        }
+
+        return ApiResponseGenerator.success(HttpStatus.OK, "모임별 개인 선호/비선호 음식 조회 성공", preferences);
     }
 
-    return ApiResponseGenerator.success(HttpStatus.OK, "모임별 개인 선호/비선호 음식 조회 성공", preferences);
-  }
+    @PutMapping("/{meeting_id}/personal")
+    public ResponseEntity<ApiResponseBody.SuccessBody<PersonalPreferenceUpdateRequest>> updatePreferences(
+            @LoginMemberId Long memberId,
+            @PathVariable("meeting_id") Long meetingId,
+            @RequestBody PersonalPreferenceUpdateRequest PersonalPreferenceRequestDto
+    ) {
+        meetingFoodPreferenceUpdater.updatePreferences(
+                meetingId,
+                memberId,
+                PersonalPreferenceRequestDto.preferences(),
+                PersonalPreferenceRequestDto.nonPreferences()
+        );
 
-  @PutMapping("/{meeting_id}/personal")
-  public ResponseEntity<ApiResponseBody.SuccessBody<PersonalPreferenceUpdateRequest>> updatePreferences(
-      @LoginMemberId Long memberId,
-      @PathVariable("meeting_id") Long meetingId,
-      @RequestBody PersonalPreferenceUpdateRequest PersonalPreferenceRequestDto
-  ) {
-    meetingFoodPreferenceUpdater.updatePreferences(
-        meetingId,
-        memberId,
-        PersonalPreferenceRequestDto.preferences(),
-        PersonalPreferenceRequestDto.nonPreferences()
-    );
+        return ApiResponseGenerator.success(HttpStatus.OK, "모임별 개인 정보 수정 성공", PersonalPreferenceRequestDto);
+    }
 
-    return ApiResponseGenerator.success(HttpStatus.OK, "모임별 개인 정보 수정 성공", PersonalPreferenceRequestDto);
-  }
+    @GetMapping("/{meetingId}/recommend")
+    public ResponseEntity<ApiResponseBody.SuccessBody<List<FoodPreferenceGetResponse>>> getRecommendedFoodsForMeeting(
+            @PathVariable Long meetingId
+    ) {
 
-  @GetMapping("/{meetingId}/recommend")
-  public ResponseEntity<ApiResponseBody.SuccessBody<List<FoodPreferenceGetResponse>>> getRecommendedFoodsForMeeting(
-      @PathVariable Long meetingId
-  ) {
+        List<FoodPreferenceGetResponse> recommendedFoods = meetingPreferenceService.getRecommendedFoodDetailsForMeeting(meetingId);
 
-    List<FoodPreferenceGetResponse> recommendedFoods = meetingPreferenceService.getRecommendedFoodDetailsForMeeting(meetingId);
-
-    return ApiResponseGenerator.success(HttpStatus.OK, "모임 추천 음식 조회 성공", recommendedFoods);
-  }
+        return ApiResponseGenerator.success(HttpStatus.OK, "모임 추천 음식 조회 성공", recommendedFoods);
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodPreferenceGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodPreferenceGetResponse.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.food.dto;
 
+import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.entity.MeetingNonPreferenceFood;
 import org.cookieandkakao.babting.domain.food.entity.MeetingPreferenceFood;
 import org.cookieandkakao.babting.domain.food.entity.NonPreferenceFood;
@@ -36,5 +37,12 @@ public record FoodPreferenceGetResponse(
         nonPreferenceFood.getFood().getFoodId(),
         nonPreferenceFood.getFood().getFoodCategory().getName(),
         nonPreferenceFood.getFood().getName());
+  }
+
+  public static FoodPreferenceGetResponse fromFood(Food food) {
+    return new FoodPreferenceGetResponse(
+            food.getFoodId(),
+            food.getFoodCategory().getName(),
+            food.getName());
   }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodPreferenceGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodPreferenceGetResponse.java
@@ -1,6 +1,5 @@
 package org.cookieandkakao.babting.domain.food.dto;
 
-import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.entity.MeetingNonPreferenceFood;
 import org.cookieandkakao.babting.domain.food.entity.MeetingPreferenceFood;
 import org.cookieandkakao.babting.domain.food.entity.NonPreferenceFood;

--- a/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodPreferenceGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/dto/FoodPreferenceGetResponse.java
@@ -1,8 +1,41 @@
 package org.cookieandkakao.babting.domain.food.dto;
 
+import org.cookieandkakao.babting.domain.food.entity.Food;
+import org.cookieandkakao.babting.domain.food.entity.MeetingNonPreferenceFood;
+import org.cookieandkakao.babting.domain.food.entity.MeetingPreferenceFood;
+import org.cookieandkakao.babting.domain.food.entity.NonPreferenceFood;
+import org.cookieandkakao.babting.domain.food.entity.PreferenceFood;
+
 public record FoodPreferenceGetResponse(
-        Long foodId,
-        String category,
-        String name
+    Long foodId,
+    String category,
+    String name
 ) {
+  public static FoodPreferenceGetResponse fromMeetingPreferenceFood(MeetingPreferenceFood meetingPreferenceFood) {
+    return new FoodPreferenceGetResponse(
+        meetingPreferenceFood.getFood().getFoodId(),
+        meetingPreferenceFood.getFood().getFoodCategory().getName(),
+        meetingPreferenceFood.getFood().getName());
+  }
+
+  public static FoodPreferenceGetResponse fromMeetingNonPreferenceFood(MeetingNonPreferenceFood meetingNonPreferenceFood) {
+    return new FoodPreferenceGetResponse(
+        meetingNonPreferenceFood.getFood().getFoodId(),
+        meetingNonPreferenceFood.getFood().getFoodCategory().getName(),
+        meetingNonPreferenceFood.getFood().getName());
+  }
+
+  public static FoodPreferenceGetResponse fromPreferenceFood(PreferenceFood preferenceFood) {
+    return new FoodPreferenceGetResponse(
+        preferenceFood.getFood().getFoodId(),
+        preferenceFood.getFood().getFoodCategory().getName(),
+        preferenceFood.getFood().getName());
+  }
+
+  public static FoodPreferenceGetResponse fromNonPreferenceFood(NonPreferenceFood nonPreferenceFood) {
+    return new FoodPreferenceGetResponse(
+        nonPreferenceFood.getFood().getFoodId(),
+        nonPreferenceFood.getFood().getFoodCategory().getName(),
+        nonPreferenceFood.getFood().getName());
+  }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodRepositoryService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodRepositoryService.java
@@ -1,5 +1,7 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import org.cookieandkakao.babting.common.exception.customexception.FoodNotFoundException;
+import org.cookieandkakao.babting.common.exception.customexception.PreferenceConflictException;
 import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.repository.FoodRepository;
 import org.cookieandkakao.babting.domain.food.repository.NonPreferenceFoodRepository;
@@ -29,16 +31,16 @@ public class FoodRepositoryService {
 
     public Food findFoodById(Long foodId) {
         return foodRepository.findById(foodId)
-                .orElseThrow(() -> new RuntimeException("해당 음식을 찾을 수 없습니다."));
+                .orElseThrow(() -> new FoodNotFoundException("해당 음식을 찾을 수 없습니다."));
     }
 
     public void validateNotAlreadyPreferredOrNonPreferred(Food food, Member member) {
         if (nonPreferenceFoodRepository.existsByFoodAndMember(food, member)) {
-            throw new RuntimeException("해당 음식은 이미 비선호 음식으로 등록되어 있습니다.");
+            throw new PreferenceConflictException("해당 음식은 이미 비선호 음식으로 등록되어 있습니다.");
         }
 
         if (preferenceFoodRepository.existsByFoodAndMember(food, member)) {
-            throw new RuntimeException("해당 음식은 이미 선호 음식으로 등록되어 있습니다.");
+            throw new PreferenceConflictException("해당 음식은 이미 선호 음식으로 등록되어 있습니다.");
         }
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodRepositoryService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodRepositoryService.java
@@ -7,6 +7,9 @@ import org.cookieandkakao.babting.domain.food.repository.PreferenceFoodRepositor
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Set;
+
 @Service
 public class FoodRepositoryService {
 
@@ -37,5 +40,9 @@ public class FoodRepositoryService {
         if (preferenceFoodRepository.existsByFoodAndMember(food, member)) {
             throw new RuntimeException("해당 음식은 이미 선호 음식으로 등록되어 있습니다.");
         }
+    }
+
+    public List<Food> findFoodsByIds(Set<Long> foodIds) {
+        return foodRepository.findAllById(foodIds);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodService.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import org.cookieandkakao.babting.common.exception.customexception.FoodNotFoundException;
 import org.cookieandkakao.babting.domain.food.dto.FoodGetResponse;
 import org.cookieandkakao.babting.domain.food.entity.FoodCategory;
 import org.cookieandkakao.babting.domain.food.repository.FoodCategoryRepository;
@@ -22,7 +23,7 @@ public class FoodService {
 
     public List<FoodGetResponse> getFoodsByCategory(String categoryName) {
         FoodCategory category = foodCategoryRepository.findByName(categoryName)
-                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다."));
+                .orElseThrow(() -> new FoodNotFoundException("해당 카테고리가 존재하지 않습니다."));
 
         return foodRepository.findByFoodCategory(category)
                 .stream()

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceStrategy.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceStrategy.java
@@ -1,6 +1,7 @@
 package org.cookieandkakao.babting.domain.food.service;
 
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
+
 import java.util.List;
 
 public interface MeetingFoodPreferenceStrategy {

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceUpdater.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceUpdater.java
@@ -54,17 +54,17 @@ public class MeetingFoodPreferenceUpdater {
         List<Long> allFoodIds = new ArrayList<>(preferences); //preferences 리스트의 모든 아이디 추가하기
         allFoodIds.addAll(nonPreferences);//nonPreferences 리스트의 모든 아이디 추가하기
         Map<Long, Food> foodsMap = foodRepositoryService.findFoodsByIds(new HashSet<>(allFoodIds))
-            .stream().collect(Collectors.toMap(Food::getFoodId, Function.identity()));
+                .stream().collect(Collectors.toMap(Food::getFoodId, Function.identity()));
 
         // 선호음식 stream 생성
         List<MeetingPreferenceFood> newPreferenceFoods = preferences.stream()
-            .map(foodId -> new MeetingPreferenceFood(foodsMap.get(foodId), memberMeeting))
-            .collect(Collectors.toList());
+                .map(foodId -> new MeetingPreferenceFood(foodsMap.get(foodId), memberMeeting))
+                .collect(Collectors.toList());
 
         // 비선호음식 stream 생성
         List<MeetingNonPreferenceFood> newNonPreferenceFoods = nonPreferences.stream()
-            .map(foodId -> new MeetingNonPreferenceFood(foodsMap.get(foodId), memberMeeting))
-            .collect(Collectors.toList());
+                .map(foodId -> new MeetingNonPreferenceFood(foodsMap.get(foodId), memberMeeting))
+                .collect(Collectors.toList());
 
         meetingPreferenceFoodRepository.saveAll(newPreferenceFoods);
         meetingNonPreferenceFoodRepository.saveAll(newNonPreferenceFoods);

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceUpdater.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceUpdater.java
@@ -13,7 +13,12 @@ import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class MeetingFoodPreferenceUpdater {
@@ -46,18 +51,22 @@ public class MeetingFoodPreferenceUpdater {
         meetingPreferenceFoodRepository.deleteAllByMemberMeeting(memberMeeting);
         meetingNonPreferenceFoodRepository.deleteAllByMemberMeeting(memberMeeting);
 
-        // 새로운 선호 음식 추가
-        preferences.forEach(foodId -> {
-            Food food = foodRepositoryService.findFoodById(foodId);
-            MeetingPreferenceFood preferenceFood = new MeetingPreferenceFood(food, memberMeeting);
-            meetingPreferenceFoodRepository.save(preferenceFood);
-        });
+        List<Long> allFoodIds = new ArrayList<>(preferences); //preferences 리스트의 모든 아이디 추가하기
+        allFoodIds.addAll(nonPreferences);//nonPreferences 리스트의 모든 아이디 추가하기
+        Map<Long, Food> foodsMap = foodRepositoryService.findFoodsByIds(new HashSet<>(allFoodIds))
+            .stream().collect(Collectors.toMap(Food::getFoodId, Function.identity()));
 
-        // 새로운 비선호 음식 추가
-        nonPreferences.forEach(foodId -> {
-            Food food = foodRepositoryService.findFoodById(foodId);
-            MeetingNonPreferenceFood nonPreferenceFood = new MeetingNonPreferenceFood(food, memberMeeting);
-            meetingNonPreferenceFoodRepository.save(nonPreferenceFood);
-        });
+        // 선호음식 stream 생성
+        List<MeetingPreferenceFood> newPreferenceFoods = preferences.stream()
+            .map(foodId -> new MeetingPreferenceFood(foodsMap.get(foodId), memberMeeting))
+            .collect(Collectors.toList());
+
+        // 비선호음식 stream 생성
+        List<MeetingNonPreferenceFood> newNonPreferenceFoods = nonPreferences.stream()
+            .map(foodId -> new MeetingNonPreferenceFood(foodsMap.get(foodId), memberMeeting))
+            .collect(Collectors.toList());
+
+        meetingPreferenceFoodRepository.saveAll(newPreferenceFoods);
+        meetingNonPreferenceFoodRepository.saveAll(newNonPreferenceFoods);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceUpdater.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingFoodPreferenceUpdater.java
@@ -13,10 +13,10 @@ import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -51,9 +51,9 @@ public class MeetingFoodPreferenceUpdater {
         meetingPreferenceFoodRepository.deleteAllByMemberMeeting(memberMeeting);
         meetingNonPreferenceFoodRepository.deleteAllByMemberMeeting(memberMeeting);
 
-        List<Long> allFoodIds = new ArrayList<>(preferences); //preferences 리스트의 모든 아이디 추가하기
-        allFoodIds.addAll(nonPreferences);//nonPreferences 리스트의 모든 아이디 추가하기
-        Map<Long, Food> foodsMap = foodRepositoryService.findFoodsByIds(new HashSet<>(allFoodIds))
+        Set<Long> allFoodIds = new HashSet<>(preferences);
+        allFoodIds.addAll(nonPreferences);
+        Map<Long, Food> foodsMap = foodRepositoryService.findFoodsByIds(allFoodIds)
                 .stream().collect(Collectors.toMap(Food::getFoodId, Function.identity()));
 
         // 선호음식 stream 생성

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingNonPreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingNonPreferenceFoodService.java
@@ -36,7 +36,7 @@ public class MeetingNonPreferenceFoodService implements MeetingFoodPreferenceStr
         MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
 
         return meetingNonPreferenceFoodRepository.findAllByMemberMeeting(memberMeeting).stream()
-            .map(FoodPreferenceGetResponse::fromMeetingNonPreferenceFood)
-            .collect(Collectors.toList());
+                .map(FoodPreferenceGetResponse::fromMeetingNonPreferenceFood)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingNonPreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingNonPreferenceFoodService.java
@@ -36,10 +36,7 @@ public class MeetingNonPreferenceFoodService implements MeetingFoodPreferenceStr
         MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
 
         return meetingNonPreferenceFoodRepository.findAllByMemberMeeting(memberMeeting).stream()
-                .map(meetingNonPreferenceFood -> new FoodPreferenceGetResponse(
-                        meetingNonPreferenceFood.getFood().getFoodId(),
-                        meetingNonPreferenceFood.getFood().getFoodCategory().getName(),
-                        meetingNonPreferenceFood.getFood().getName()))
-                .collect(Collectors.toList());
+            .map(FoodPreferenceGetResponse::fromMeetingNonPreferenceFood)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceFoodService.java
@@ -36,10 +36,7 @@ public class MeetingPreferenceFoodService implements MeetingFoodPreferenceStrate
         MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
 
         return meetingPreferenceFoodRepository.findAllByMemberMeeting(memberMeeting).stream()
-                .map(meetingPreferenceFood -> new FoodPreferenceGetResponse(
-                        meetingPreferenceFood.getFood().getFoodId(),
-                        meetingPreferenceFood.getFood().getFoodCategory().getName(),
-                        meetingPreferenceFood.getFood().getName()))
-                .collect(Collectors.toList());
+            .map(FoodPreferenceGetResponse::fromMeetingPreferenceFood)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceFoodService.java
@@ -36,7 +36,7 @@ public class MeetingPreferenceFoodService implements MeetingFoodPreferenceStrate
         MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
 
         return meetingPreferenceFoodRepository.findAllByMemberMeeting(memberMeeting).stream()
-            .map(FoodPreferenceGetResponse::fromMeetingPreferenceFood)
-            .collect(Collectors.toList());
+                .map(FoodPreferenceGetResponse::fromMeetingPreferenceFood)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
@@ -1,6 +1,8 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.entity.MeetingNonPreferenceFood;
+import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.entity.MeetingPreferenceFood;
 import org.cookieandkakao.babting.domain.food.entity.NonPreferenceFood;
 import org.cookieandkakao.babting.domain.food.repository.MeetingNonPreferenceFoodRepository;
@@ -22,19 +24,33 @@ public class MeetingPreferenceService {
     private final MeetingPreferenceFoodRepository meetingPreferenceFoodRepository;
     private final MeetingNonPreferenceFoodRepository meetingNonPreferenceFoodRepository;
     private final NonPreferenceFoodRepository nonPreferenceFoodRepository;
+    private final FoodRepositoryService foodRepositoryService;
 
     public MeetingPreferenceService(MemberMeetingRepository memberMeetingRepository,
                                     MeetingPreferenceFoodRepository meetingPreferenceFoodRepository,
                                     MeetingNonPreferenceFoodRepository meetingNonPreferenceFoodRepository,
-                                    NonPreferenceFoodRepository nonPreferenceFoodRepository
+                                    NonPreferenceFoodRepository nonPreferenceFoodRepository,
+                                    FoodRepositoryService foodRepositoryService
     ) {
         this.memberMeetingRepository = memberMeetingRepository;
         this.meetingPreferenceFoodRepository = meetingPreferenceFoodRepository;
         this.meetingNonPreferenceFoodRepository = meetingNonPreferenceFoodRepository;
         this.nonPreferenceFoodRepository = nonPreferenceFoodRepository;
+        this.foodRepositoryService = foodRepositoryService;
     }
 
-    public Set<Long> getRecommendedFoodsForMeeting(Long meetingId) {
+    public List<FoodPreferenceGetResponse> getRecommendedFoodDetailsForMeeting(Long meetingId) {
+        Set<Long> recommendedFoodIds = getRecommendedFoodsForMeeting(meetingId);
+        List<Food> foods = foodRepositoryService.findFoodsByIds(recommendedFoodIds);
+        return foods.stream()
+            .map(food -> new FoodPreferenceGetResponse(
+                food.getFoodId(),
+                food.getFoodCategory().getName(),
+                food.getName()))
+            .collect(Collectors.toList());
+    }
+
+    private Set<Long> getRecommendedFoodsForMeeting(Long meetingId) {
         List<MemberMeeting> memberMeetings = memberMeetingRepository.findMemberMeetingsByMeetingId(meetingId);
         List<Member> members = memberMeetingRepository.findMembersByMeetingId(meetingId);
 

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
@@ -10,7 +10,6 @@ import org.cookieandkakao.babting.domain.food.repository.MeetingPreferenceFoodRe
 import org.cookieandkakao.babting.domain.food.repository.NonPreferenceFoodRepository;
 import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
 import org.cookieandkakao.babting.domain.meeting.repository.MemberMeetingRepository;
-import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
@@ -48,7 +47,6 @@ public class MeetingPreferenceService {
 
     private List<Food> getRecommendedFoodsForMeeting(Long meetingId) {
         List<MemberMeeting> memberMeetings = memberMeetingRepository.findMemberMeetingsByMeetingId(meetingId);
-        List<Member> members = memberMeetingRepository.findMembersByMeetingId(meetingId);
 
         // 모든 멤버의 모임별 선호 음식 ID를 Set으로 수집
         Set<Long> preferredFoodIds = new HashSet<>();
@@ -68,8 +66,8 @@ public class MeetingPreferenceService {
         }
 
         // 모든 멤버의 개인 비선호 음식 ID를 Set으로 수집하고 선호 음식 ID에서 제거
-        for (Member member : members) {
-            List<NonPreferenceFood> nonPreferenceFoods = nonPreferenceFoodRepository.findAllByMember(member);
+        for (MemberMeeting memberMeeting : memberMeetings) {
+            List<NonPreferenceFood> nonPreferenceFoods = nonPreferenceFoodRepository.findAllByMember(memberMeeting.getMember());
             for (NonPreferenceFood nonPreference : nonPreferenceFoods) {
                 preferredFoodIds.remove(nonPreference.getFood().getFoodId());
             }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
@@ -42,10 +42,7 @@ public class MeetingPreferenceService {
     public List<FoodPreferenceGetResponse> getRecommendedFoodDetailsForMeeting(Long meetingId) {
         List<Food> recommendedFoods = getRecommendedFoodsForMeeting(meetingId);
         return recommendedFoods.stream()
-                .map(food -> new FoodPreferenceGetResponse(
-                        food.getFoodId(),
-                        food.getFoodCategory().getName(),
-                        food.getName()))
+                .map(FoodPreferenceGetResponse::fromFood)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
@@ -40,9 +40,8 @@ public class MeetingPreferenceService {
     }
 
     public List<FoodPreferenceGetResponse> getRecommendedFoodDetailsForMeeting(Long meetingId) {
-        Set<Long> recommendedFoodIds = getRecommendedFoodsForMeeting(meetingId);
-        List<Food> foods = foodRepositoryService.findFoodsByIds(recommendedFoodIds);
-        return foods.stream()
+        List<Food> recommendedFoods = getRecommendedFoodsForMeeting(meetingId);
+        return recommendedFoods.stream()
                 .map(food -> new FoodPreferenceGetResponse(
                         food.getFoodId(),
                         food.getFoodCategory().getName(),
@@ -50,7 +49,7 @@ public class MeetingPreferenceService {
                 .collect(Collectors.toList());
     }
 
-    private Set<Long> getRecommendedFoodsForMeeting(Long meetingId) {
+    private List<Food> getRecommendedFoodsForMeeting(Long meetingId) {
         List<MemberMeeting> memberMeetings = memberMeetingRepository.findMemberMeetingsByMeetingId(meetingId);
         List<Member> members = memberMeetingRepository.findMembersByMeetingId(meetingId);
 
@@ -79,6 +78,6 @@ public class MeetingPreferenceService {
             }
         }
 
-        return preferredFoodIds;
+        return foodRepositoryService.findFoodsByIds(preferredFoodIds);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/MeetingPreferenceService.java
@@ -1,8 +1,8 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.entity.MeetingNonPreferenceFood;
-import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.entity.MeetingPreferenceFood;
 import org.cookieandkakao.babting.domain.food.entity.NonPreferenceFood;
 import org.cookieandkakao.babting.domain.food.repository.MeetingNonPreferenceFoodRepository;
@@ -43,11 +43,11 @@ public class MeetingPreferenceService {
         Set<Long> recommendedFoodIds = getRecommendedFoodsForMeeting(meetingId);
         List<Food> foods = foodRepositoryService.findFoodsByIds(recommendedFoodIds);
         return foods.stream()
-            .map(food -> new FoodPreferenceGetResponse(
-                food.getFoodId(),
-                food.getFoodCategory().getName(),
-                food.getName()))
-            .collect(Collectors.toList());
+                .map(food -> new FoodPreferenceGetResponse(
+                        food.getFoodId(),
+                        food.getFoodCategory().getName(),
+                        food.getName()))
+                .collect(Collectors.toList());
     }
 
     private Set<Long> getRecommendedFoodsForMeeting(Long meetingId) {
@@ -59,8 +59,8 @@ public class MeetingPreferenceService {
         for (MemberMeeting memberMeeting : memberMeetings) {
             List<MeetingPreferenceFood> preferenceFoods = meetingPreferenceFoodRepository.findAllByMemberMeeting(memberMeeting);
             preferredFoodIds.addAll(preferenceFoods.stream()
-                .map(preference -> preference.getFood().getFoodId())
-                .collect(Collectors.toSet()));
+                    .map(preference -> preference.getFood().getFoodId())
+                    .collect(Collectors.toSet()));
         }
 
         // 모든 멤버의 모임별 비선호 음식 ID를 Set으로 수집하고 선호 음식 ID에서 제거

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/NonPreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/NonPreferenceFoodService.java
@@ -34,11 +34,8 @@ public class NonPreferenceFoodService implements FoodPreferenceStrategy {
         Member member = memberService.findMember(memberId);
 
         return nonPreferenceFoodRepository.findAllByMember(member).stream()
-                .map(nonPreferenceFood -> new FoodPreferenceGetResponse(
-                        nonPreferenceFood.getFood().getFoodId(),
-                        nonPreferenceFood.getFood().getFoodCategory().getName(),
-                        nonPreferenceFood.getFood().getName()))
-                .collect(Collectors.toList());
+            .map(FoodPreferenceGetResponse::fromNonPreferenceFood)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/NonPreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/NonPreferenceFoodService.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import org.cookieandkakao.babting.common.exception.customexception.FoodNotFoundException;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceCreateRequest;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.entity.Food;
@@ -34,8 +35,8 @@ public class NonPreferenceFoodService implements FoodPreferenceStrategy {
         Member member = memberService.findMember(memberId);
 
         return nonPreferenceFoodRepository.findAllByMember(member).stream()
-            .map(FoodPreferenceGetResponse::fromNonPreferenceFood)
-            .collect(Collectors.toList());
+                .map(FoodPreferenceGetResponse::fromNonPreferenceFood)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -60,7 +61,7 @@ public class NonPreferenceFoodService implements FoodPreferenceStrategy {
         Member member = memberService.findMember(memberId);
 
         nonPreferenceFoodRepository.findByFoodAndMember(food, member)
-                .orElseThrow(() -> new RuntimeException("해당 비선호 음식을 찾을 수 없습니다."));
+                .orElseThrow(() -> new FoodNotFoundException("해당 비선호 음식을 찾을 수 없습니다."));
         nonPreferenceFoodRepository.deleteByFoodAndMember(food, member);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/PreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/PreferenceFoodService.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import org.cookieandkakao.babting.common.exception.customexception.FoodNotFoundException;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceCreateRequest;
 import org.cookieandkakao.babting.domain.food.dto.FoodPreferenceGetResponse;
 import org.cookieandkakao.babting.domain.food.entity.Food;
@@ -34,8 +35,8 @@ public class PreferenceFoodService implements FoodPreferenceStrategy {
         Member member = memberService.findMember(memberId);
 
         return preferenceFoodRepository.findAllByMember(member).stream()
-            .map(FoodPreferenceGetResponse::fromPreferenceFood)
-            .collect(Collectors.toList());
+                .map(FoodPreferenceGetResponse::fromPreferenceFood)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -60,7 +61,7 @@ public class PreferenceFoodService implements FoodPreferenceStrategy {
         Member member = memberService.findMember(memberId);
 
         preferenceFoodRepository.findByFoodAndMember(food, member)
-                .orElseThrow(() -> new RuntimeException("해당 선호 음식을 찾을 수 없습니다."));
+                .orElseThrow(() -> new FoodNotFoundException("해당 선호 음식을 찾을 수 없습니다."));
         preferenceFoodRepository.deleteByFoodAndMember(food, member);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/PreferenceFoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/PreferenceFoodService.java
@@ -34,11 +34,8 @@ public class PreferenceFoodService implements FoodPreferenceStrategy {
         Member member = memberService.findMember(memberId);
 
         return preferenceFoodRepository.findAllByMember(member).stream()
-                .map(preferenceFood -> new FoodPreferenceGetResponse(
-                        preferenceFood.getFood().getFoodId(),
-                        preferenceFood.getFood().getFoodCategory().getName(),
-                        preferenceFood.getFood().getName()))
-                .collect(Collectors.toList());
+            .map(FoodPreferenceGetResponse::fromPreferenceFood)
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
@@ -19,7 +19,5 @@ public interface MemberMeetingRepository extends JpaRepository<MemberMeeting, Lo
     void deleteAllByMeeting(Meeting meeting);
     @Query("SELECT mm FROM MemberMeeting mm WHERE mm.meeting.meetingId = :meetingId")
     List<MemberMeeting> findMemberMeetingsByMeetingId(@Param("meetingId") Long meetingId);
-    @Query("SELECT mm.member FROM MemberMeeting mm WHERE mm.meeting.meetingId = :meetingId")
-    List<Member> findMembersByMeetingId(@Param("meetingId") Long meetingId);
     Optional<List<MemberMeeting>> findByMeeting(Meeting meeting);
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MemberMeetingRepository.java
@@ -17,7 +17,8 @@ public interface MemberMeetingRepository extends JpaRepository<MemberMeeting, Lo
     List<Meeting> findMeetingsByMember(@Param("member") Member member);
     boolean existsByMemberAndMeeting(Member member, Meeting meeting);
     void deleteAllByMeeting(Meeting meeting);
-
+    @Query("SELECT mm FROM MemberMeeting mm WHERE mm.meeting.meetingId = :meetingId")
+    List<MemberMeeting> findMemberMeetingsByMeetingId(@Param("meetingId") Long meetingId);
     @Query("SELECT mm.member FROM MemberMeeting mm WHERE mm.meeting.meetingId = :meetingId")
     List<Member> findMembersByMeetingId(@Param("meetingId") Long meetingId);
     Optional<List<MemberMeeting>> findByMeeting(Meeting meeting);


### PR DESCRIPTION
## 주요 변경사항

커스텀 예외 처리 적용
정적팩토리메서드 적용
비즈니스로직 서비스클래스로 이동
쿼리횟수 줄이기(MeetingFoodPreferenceUpdater, MeetingPreferenceService)
모임별 추천 음식 계산 로직 변경
그 외 자잘한 피드백 반영

## 리뷰어에게...

아직 시험이 몇개 남아있어서 늦게 pr 날립니다
테스트코드와 남은 피드백(Sting -> enum으로 변경 등)은 다음주에 꼭!! 구현하도록 하겠습니다

## 관련 이슈

closes #

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
