### PR TITLE
[FEAT, REFACTOR] 토큰 재발급 기능 추가, 카카오 토큰 관련 기능 리펙토링

### DIFF
--- a/src/main/java/org/cookieandkakao/babting/common/annotaion/LoginMemberId.java
+++ b/src/main/java/org/cookieandkakao/babting/common/annotaion/LoginMemberId.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.common.annotaion;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +8,7 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface LoginMemberId {
 
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/AuthController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/AuthController.java
@@ -77,6 +77,7 @@ public class AuthController {
     @ResponseBody
     @GetMapping("access-token")
     @Operation(summary = "접근 토큰 재발급", description = "접근 토큰을 Authorization 헤더로 재발급합니다.")
+    @ApiResponse(responseCode = "200", description = "접근 토큰 발급 성공")
     public ResponseEntity<ApiResponseBody.SuccessBody<Void>> reissueToken(
         @Parameter(hidden = true) @CookieValue(required = false) String refreshToken,
         HttpServletResponse response) {

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/AuthController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/AuthController.java
@@ -2,23 +2,35 @@ package org.cookieandkakao.babting.domain.member.controller;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody;
+import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
 import org.cookieandkakao.babting.domain.member.dto.KakaoMemberInfoGetResponse;
 import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
 import org.cookieandkakao.babting.domain.member.dto.TokenIssueResponse;
 import org.cookieandkakao.babting.domain.member.service.AuthService;
+import org.cookieandkakao.babting.domain.member.util.JwtUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final AuthService authService;
+    private static final int REFRESH_TOKEN_EXPIRES_IN = 1000 * 60 * 60 * 24 * 14;  // 2주
 
-    public AuthController(AuthService authService) {
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+
+    public AuthController(AuthService authService, JwtUtil jwtUtil) {
         this.authService = authService;
+        this.jwtUtil = jwtUtil;
     }
 
     @GetMapping("/login")
@@ -40,20 +52,32 @@ public class AuthController {
             return "redirect:/login/fail";  // 프론트 페이지 구현 후 수정 예정
         }
 
-        authService.saveMemberInfoAndKakaoToken(kakaoMemberInfoDto, kakaoTokenDto);
-        TokenIssueResponse tokenDto = authService.issueToken(kakaoMemberInfoDto.id());
+        Long memberId = authService.saveMemberInfoAndKakaoToken(kakaoMemberInfoDto, kakaoTokenDto);
+        TokenIssueResponse tokenDto = authService.issueToken(memberId);
 
-        Cookie accessTokenCookie = new Cookie("accessToken", tokenDto.accessToken());
-        accessTokenCookie.setPath("/");
-
-        Cookie refreshTokenCookie = new Cookie("refreshToken", tokenDto.refreshToken());
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 14); // 2주
-
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        response.addCookie(createRefreshTokenCookie(tokenDto));
 
         return "redirect:/login/success";  // 프론트 페이지 구현 후 수정 예정
+    }
+
+    @GetMapping("access-token")
+    @ResponseBody
+    public ResponseEntity<ApiResponseBody.SuccessBody<Void>> reissueToken(
+        @CookieValue(required = false) String refreshToken, HttpServletResponse response) {
+
+        Long memberId = Long.parseLong(jwtUtil.parseClaims(refreshToken).getSubject());
+        TokenIssueResponse tokenDto = authService.issueToken(memberId);
+
+        response.setHeader("Authorization", tokenDto.accessToken());
+
+        return ApiResponseGenerator.success(HttpStatus.OK, "토큰 재발급 성공");
+    }
+
+    private static Cookie createRefreshTokenCookie(TokenIssueResponse tokenDto) {
+        Cookie refreshTokenCookie = new Cookie("refreshToken", tokenDto.refreshToken());
+        refreshTokenCookie.setPath("/api/auth/access-token");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setMaxAge(REFRESH_TOKEN_EXPIRES_IN);
+        return refreshTokenCookie;
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/AuthController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.cookieandkakao.babting.domain.member.dto.KakaoMemberInfoGetResponse;
 import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
 import org.cookieandkakao.babting.domain.member.dto.TokenIssueResponse;
 import org.cookieandkakao.babting.domain.member.service.AuthService;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.cookieandkakao.babting.domain.member.util.JwtUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,10 +28,12 @@ public class AuthController {
 
     private final AuthService authService;
     private final JwtUtil jwtUtil;
+    private final MemberService memberService;
 
-    public AuthController(AuthService authService, JwtUtil jwtUtil) {
+    public AuthController(AuthService authService, JwtUtil jwtUtil, MemberService memberService) {
         this.authService = authService;
         this.jwtUtil = jwtUtil;
+        this.memberService = memberService;
     }
 
     @GetMapping("/login")
@@ -52,7 +55,7 @@ public class AuthController {
             return "redirect:/login/fail";  // 프론트 페이지 구현 후 수정 예정
         }
 
-        Long memberId = authService.saveMemberInfoAndKakaoToken(kakaoMemberInfoDto, kakaoTokenDto);
+        Long memberId = memberService.saveMemberInfoAndKakaoToken(kakaoMemberInfoDto, kakaoTokenDto);
         TokenIssueResponse tokenDto = authService.issueToken(memberId);
 
         response.addCookie(createRefreshTokenCookie(tokenDto));

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package org.cookieandkakao.babting.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody;
@@ -28,6 +30,7 @@ public class MemberController {
 
     @GetMapping
     @Operation(summary = "회원 프로필 조회", description = "현재 로그인된 회원 본인의 프로필을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인된 회원 본인의 프로필 정보")
     public ResponseEntity<ApiResponseBody.SuccessBody<MemberProfileGetResponse>> getMemberProfile(
         @Parameter(hidden = true) @LoginMemberId Long memberId) {
         MemberProfileGetResponse memberProfile = memberService.getMemberProfile(memberId);
@@ -36,6 +39,7 @@ public class MemberController {
 
     @DeleteMapping
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.")
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공 메세지")
     public ResponseEntity<ApiResponseBody.SuccessBody<Void>> deleteMember(
         @Parameter(hidden = true) @LoginMemberId Long memberId) {
         memberService.deleteMember(memberId);

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
@@ -1,5 +1,8 @@
 package org.cookieandkakao.babting.domain.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
@@ -12,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "회원", description = "회원 관련 api입니다.")
 @RestController
 @RequestMapping("/api/members")
 public class MemberController {
@@ -23,15 +27,17 @@ public class MemberController {
     }
 
     @GetMapping
+    @Operation(summary = "회원 프로필 조회", description = "현재 로그인된 회원 본인의 프로필을 조회합니다.")
     public ResponseEntity<ApiResponseBody.SuccessBody<MemberProfileGetResponse>> getMemberProfile(
-        @LoginMemberId Long memberId) {
+        @Parameter(hidden = true) @LoginMemberId Long memberId) {
         MemberProfileGetResponse memberProfile = memberService.getMemberProfile(memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "프로필 조회 성공", memberProfile);
     }
 
     @DeleteMapping
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.")
     public ResponseEntity<ApiResponseBody.SuccessBody<Void>> deleteMember(
-        @LoginMemberId Long memberId) {
+        @Parameter(hidden = true) @LoginMemberId Long memberId) {
         memberService.deleteMember(memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "회원 탈퇴 성공");
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package org.cookieandkakao.babting.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.cookieandkakao.babting.common.annotaion.LoginMemberId;
@@ -32,7 +31,7 @@ public class MemberController {
     @Operation(summary = "회원 프로필 조회", description = "현재 로그인된 회원 본인의 프로필을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "로그인된 회원 본인의 프로필 정보")
     public ResponseEntity<ApiResponseBody.SuccessBody<MemberProfileGetResponse>> getMemberProfile(
-        @Parameter(hidden = true) @LoginMemberId Long memberId) {
+        @LoginMemberId Long memberId) {
         MemberProfileGetResponse memberProfile = memberService.getMemberProfile(memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "프로필 조회 성공", memberProfile);
     }
@@ -41,7 +40,7 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.")
     @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공 메세지")
     public ResponseEntity<ApiResponseBody.SuccessBody<Void>> deleteMember(
-        @Parameter(hidden = true) @LoginMemberId Long memberId) {
+        @LoginMemberId Long memberId) {
         memberService.deleteMember(memberId);
         return ApiResponseGenerator.success(HttpStatus.OK, "회원 탈퇴 성공");
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/entity/KakaoToken.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/entity/KakaoToken.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
 
 @Entity
 public class KakaoToken {
@@ -35,6 +36,11 @@ public class KakaoToken {
         this.expiresAt = expiresAt;
         this.refreshToken = refreshToken;
         this.refreshTokenExpiresAt = refreshTokenExpiresAt;
+    }
+
+    public void updateAccessToken(KakaoTokenGetResponse kakaoTokenGetResponse) {
+        this.accessToken = kakaoTokenGetResponse.accessToken();
+        this.expiresAt = LocalDateTime.now().plusSeconds(kakaoTokenGetResponse.expiresIn());
     }
 
     public String getAccessToken() {

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
@@ -74,26 +74,6 @@ public class AuthService {
         kakaoAuthClient.callUnlinkApi(accessToken);
     }
 
-    @Transactional
-    public Long saveMemberInfoAndKakaoToken(
-        KakaoMemberInfoGetResponse kakaoMemberInfoGetResponse,
-        KakaoTokenGetResponse kakaoTokenGetResponse) {
-
-        Long kakaoMemberId = kakaoMemberInfoGetResponse.id();
-
-        Member member = memberRepository.findByKakaoMemberId(kakaoMemberId)
-            .orElse(new Member(kakaoMemberId));
-        member.updateProfile(kakaoMemberInfoGetResponse.properties());
-
-        member = memberRepository.save(member);
-
-        KakaoToken kakaoToken = kakaoTokenGetResponse.toEntity();
-
-        member.updateKakaoToken(kakaoToken);
-
-        return member.getMemberId();
-    }
-
     public TokenIssueResponse issueToken(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(IllegalArgumentException::new);

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
@@ -9,7 +9,6 @@ import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
 import org.cookieandkakao.babting.domain.member.dto.TokenIssueResponse;
 import org.cookieandkakao.babting.domain.member.entity.KakaoToken;
 import org.cookieandkakao.babting.domain.member.entity.Member;
-import org.cookieandkakao.babting.domain.member.repository.KakaoTokenRepository;
 import org.cookieandkakao.babting.domain.member.repository.MemberRepository;
 import org.cookieandkakao.babting.domain.member.util.AuthorizationUriBuilder;
 import org.cookieandkakao.babting.domain.member.util.JwtUtil;
@@ -26,15 +25,16 @@ public class AuthService {
 
     private final KakaoClientProperties kakaoClientProperties;
     private final KakaoProviderProperties kakaoProviderProperties;
-    private final RestClient restClient = RestClient.builder().build();
+    private final RestClient restClient;
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
 
     public AuthService(KakaoClientProperties kakaoClientProperties,
-        KakaoProviderProperties kakaoProviderProperties, MemberRepository memberRepository,
-        JwtUtil jwtUtil) {
+        KakaoProviderProperties kakaoProviderProperties, RestClient restClient,
+        MemberRepository memberRepository, JwtUtil jwtUtil) {
         this.kakaoClientProperties = kakaoClientProperties;
         this.kakaoProviderProperties = kakaoProviderProperties;
+        this.restClient = restClient;
         this.memberRepository = memberRepository;
         this.jwtUtil = jwtUtil;
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
@@ -1,7 +1,5 @@
 package org.cookieandkakao.babting.domain.member.service;
 
-import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
-
 import org.cookieandkakao.babting.common.properties.KakaoClientProperties;
 import org.cookieandkakao.babting.common.properties.KakaoProviderProperties;
 import org.cookieandkakao.babting.domain.member.dto.KakaoMemberInfoGetResponse;
@@ -12,29 +10,26 @@ import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.cookieandkakao.babting.domain.member.repository.MemberRepository;
 import org.cookieandkakao.babting.domain.member.util.AuthorizationUriBuilder;
 import org.cookieandkakao.babting.domain.member.util.JwtUtil;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 @Service
 public class AuthService {
 
     private final KakaoClientProperties kakaoClientProperties;
     private final KakaoProviderProperties kakaoProviderProperties;
-    private final RestClient restClient;
+    private final KakaoAuthClient kakaoAuthClient;
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
 
     public AuthService(KakaoClientProperties kakaoClientProperties,
-        KakaoProviderProperties kakaoProviderProperties, RestClient restClient,
+        KakaoProviderProperties kakaoProviderProperties, KakaoAuthClient kakaoAuthClient,
         MemberRepository memberRepository, JwtUtil jwtUtil) {
         this.kakaoClientProperties = kakaoClientProperties;
         this.kakaoProviderProperties = kakaoProviderProperties;
-        this.restClient = restClient;
+        this.kakaoAuthClient = kakaoAuthClient;
         this.memberRepository = memberRepository;
         this.jwtUtil = jwtUtil;
     }
@@ -55,54 +50,28 @@ public class AuthService {
         body.add("client_id", kakaoClientProperties.clientId());
         body.add("client_secret", kakaoClientProperties.clientSecret());
 
-        return callTokenApi(body);
+        return kakaoAuthClient.callTokenApi(body);
     }
 
     public KakaoTokenGetResponse refreshKakaoToken(String refreshToekn) {
-        
+
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "refresh_token");
         body.add("client_id", kakaoClientProperties.clientId());
         body.add("refresh_token", refreshToekn);
 
-        return callTokenApi(body);
+        return kakaoAuthClient.callTokenApi(body);
     }
 
     public KakaoMemberInfoGetResponse requestKakaoMemberInfo(
-        KakaoTokenGetResponse kakaoToken) {
+        KakaoTokenGetResponse kakaoTokenDto) {
 
-        String userInfoUri = kakaoProviderProperties.userInfoUri();
-
-        ResponseEntity<KakaoMemberInfoGetResponse> entity = restClient.get()
-            .uri(userInfoUri)
-            .header("Authorization", "Bearer " + kakaoToken.accessToken())
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .retrieve()
-            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-                throw new IllegalArgumentException("카카오 사용자 정보 조회 실패");
-            })
-            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
-                throw new RuntimeException("카카오 사용자 정보 서버 에러");
-            })
-            .toEntity(KakaoMemberInfoGetResponse.class);
-
-        return entity.getBody();
+        return kakaoAuthClient.callMemberInfoApi(kakaoTokenDto.accessToken());
     }
 
     public void unlinkMember(String accessToken) {
 
-        String unlinkUri = kakaoProviderProperties.unlinkUri();
-
-        restClient.get()
-            .uri(unlinkUri)
-            .header("Authorization", "Bearer " + accessToken)
-            .retrieve()
-            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-                throw new IllegalArgumentException("카카오 연결 끊기 실패");
-            })
-            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
-                throw new RuntimeException("카카오 인증 서버 에러");
-            });
+        kakaoAuthClient.callUnlinkApi(accessToken);
     }
 
     @Transactional
@@ -130,24 +99,5 @@ public class AuthService {
             .orElseThrow(IllegalArgumentException::new);
 
         return jwtUtil.issueToken(member.getMemberId());
-    }
-
-    private KakaoTokenGetResponse callTokenApi(MultiValueMap<String, String> body) {
-
-        String tokenUri = kakaoProviderProperties.tokenUri();
-
-        return restClient.post()
-            .uri(tokenUri)
-            .contentType(APPLICATION_FORM_URLENCODED)
-            .body(body)
-            .retrieve()
-            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-                throw new IllegalArgumentException("카카오 토큰 발급 실패");
-            })
-            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
-                throw new RuntimeException("카카오 인증 서버 에러");
-            })
-            .toEntity(KakaoTokenGetResponse.class)
-            .getBody();
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
@@ -28,16 +28,14 @@ public class AuthService {
     private final KakaoProviderProperties kakaoProviderProperties;
     private final RestClient restClient = RestClient.builder().build();
     private final MemberRepository memberRepository;
-    private final KakaoTokenRepository kakaoTokenRepository;
     private final JwtUtil jwtUtil;
 
     public AuthService(KakaoClientProperties kakaoClientProperties,
         KakaoProviderProperties kakaoProviderProperties, MemberRepository memberRepository,
-        KakaoTokenRepository kakaoTokenRepository, JwtUtil jwtUtil) {
+        JwtUtil jwtUtil) {
         this.kakaoClientProperties = kakaoClientProperties;
         this.kakaoProviderProperties = kakaoProviderProperties;
         this.memberRepository = memberRepository;
-        this.kakaoTokenRepository = kakaoTokenRepository;
         this.jwtUtil = jwtUtil;
     }
 
@@ -126,31 +124,6 @@ public class AuthService {
         memberRepository.save(member);
 
         KakaoToken kakaoToken = kakaoTokenGetResponse.toEntity();
-
-        member.updateKakaoToken(kakaoToken);
-    }
-
-    @Transactional
-    public void saveMemberInfo(KakaoMemberInfoGetResponse kakaoMemberInfoGetResponse) {
-
-        Long kakaoMemberId = kakaoMemberInfoGetResponse.id();
-
-        Member member = memberRepository.findByKakaoMemberId(kakaoMemberId)
-            .orElse(new Member(kakaoMemberId));
-        member.updateProfile(kakaoMemberInfoGetResponse.properties());
-
-        memberRepository.save(member);
-    }
-
-    @Transactional
-    public void saveKakaoToken(Long kakaoMemberId,
-        KakaoTokenGetResponse kakaoTokenGetResponse) {
-
-        Member member = memberRepository.findByKakaoMemberId(kakaoMemberId)
-            .orElseThrow(IllegalArgumentException::new);
-        KakaoToken kakaoToken = kakaoTokenGetResponse.toEntity();
-
-        kakaoTokenRepository.save(kakaoToken);
 
         member.updateKakaoToken(kakaoToken);
     }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/AuthService.java
@@ -111,7 +111,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void saveMemberInfoAndKakaoToken(
+    public Long saveMemberInfoAndKakaoToken(
         KakaoMemberInfoGetResponse kakaoMemberInfoGetResponse,
         KakaoTokenGetResponse kakaoTokenGetResponse) {
 
@@ -121,15 +121,17 @@ public class AuthService {
             .orElse(new Member(kakaoMemberId));
         member.updateProfile(kakaoMemberInfoGetResponse.properties());
 
-        memberRepository.save(member);
+        member = memberRepository.save(member);
 
         KakaoToken kakaoToken = kakaoTokenGetResponse.toEntity();
 
         member.updateKakaoToken(kakaoToken);
+
+        return member.getMemberId();
     }
 
-    public TokenIssueResponse issueToken(Long kakaoMemberId) {
-        Member member = memberRepository.findByKakaoMemberId(kakaoMemberId)
+    public TokenIssueResponse issueToken(Long memberId) {
+        Member member = memberRepository.findById(memberId)
             .orElseThrow(IllegalArgumentException::new);
 
         return jwtUtil.issueToken(member.getMemberId());

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/KakaoAuthClient.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/KakaoAuthClient.java
@@ -1,0 +1,76 @@
+package org.cookieandkakao.babting.domain.member.service;
+
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+
+import org.cookieandkakao.babting.common.properties.KakaoProviderProperties;
+import org.cookieandkakao.babting.domain.member.dto.KakaoMemberInfoGetResponse;
+import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class KakaoAuthClient {
+
+    private final KakaoProviderProperties kakaoProviderProperties;
+    private final RestClient restClient;
+
+    public KakaoAuthClient(KakaoProviderProperties kakaoProviderProperties, RestClient restClient) {
+        this.kakaoProviderProperties = kakaoProviderProperties;
+        this.restClient = restClient;
+    }
+
+    public KakaoTokenGetResponse callTokenApi(MultiValueMap<String, String> body) {
+
+        String tokenUri = kakaoProviderProperties.tokenUri();
+
+        return restClient.post()
+            .uri(tokenUri)
+            .contentType(APPLICATION_FORM_URLENCODED)
+            .body(body)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                throw new IllegalArgumentException("카카오 토큰 발급 실패");
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                throw new RuntimeException("카카오 인증 서버 에러");
+            })
+            .toEntity(KakaoTokenGetResponse.class)
+            .getBody();
+    }
+
+    public KakaoMemberInfoGetResponse callMemberInfoApi(String accessToken) {
+        String userInfoUri = kakaoProviderProperties.userInfoUri();
+
+        return restClient.get()
+            .uri(userInfoUri)
+            .header("Authorization", "Bearer " + accessToken)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                throw new IllegalArgumentException("카카오 사용자 정보 조회 실패");
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                throw new RuntimeException("카카오 사용자 정보 서버 에러");
+            })
+            .toEntity(KakaoMemberInfoGetResponse.class)
+            .getBody();
+    }
+
+    public void callUnlinkApi(String accessToken) {
+        String unlinkUri = kakaoProviderProperties.unlinkUri();
+
+        restClient.get()
+            .uri(unlinkUri)
+            .header("Authorization", "Bearer " + accessToken)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                throw new IllegalArgumentException("카카오 연결 끊기 실패");
+            })
+            .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                throw new RuntimeException("카카오 인증 서버 에러");
+            });
+    }
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package org.cookieandkakao.babting.domain.member.service;
 
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
 import org.cookieandkakao.babting.domain.member.dto.MemberProfileGetResponse;
 import org.cookieandkakao.babting.domain.member.entity.KakaoToken;
 import org.cookieandkakao.babting.domain.member.entity.Member;
@@ -40,8 +42,33 @@ public class MemberService {
         // Todo: 해당 멤버와 관련된 entity들 삭제 로직 추가
     }
 
+    @Deprecated
     public KakaoToken getKakaoToken(Long memberId) {
         Member member = findMember(memberId);
         return member.getKakaoToken();
     }
+
+    @Transactional
+    public String getKakaoAccessToken(Long memberId) {
+        Member member = findMember(memberId);
+        KakaoToken kakaoToken = member.getKakaoToken();
+
+        if (kakaoToken.getRefreshTokenExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new RuntimeException("카카오 refresh 토큰 만료");
+        }
+        else if (kakaoToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            KakaoTokenGetResponse kakaoTokenGetResponse = authService.refreshKakaoToken(
+                kakaoToken.getRefreshToken());
+            if (kakaoTokenGetResponse.refreshToken() == null) {
+                kakaoToken.updateAccessToken(kakaoTokenGetResponse);
+            }
+            else {
+                kakaoToken = kakaoTokenGetResponse.toEntity();
+                member.updateKakaoToken(kakaoToken);
+            }
+        }
+
+        return kakaoToken.getAccessToken();
+    }
+
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/service/MemberService.java
@@ -56,7 +56,7 @@ public class MemberService {
 
     @Transactional
     public void deleteMember(Long memberId) {
-        String accessToken = getKakaoToken(memberId).getAccessToken();
+        String accessToken = getKakaoAccessToken(memberId);
 
         memberRepository.deleteById(memberId);
         // Todo: 해당 멤버와 관련된 entity들 삭제 로직 추가

--- a/src/main/java/org/cookieandkakao/babting/domain/member/util/JwtUtil.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/member/util/JwtUtil.java
@@ -38,7 +38,7 @@ public class JwtUtil {
     }
 
     public TokenIssueResponse issueToken(Long userId) {
-        String accessToken = generateAccessToken(userId);
+        String accessToken = "Bearer " + generateAccessToken(userId);
         String refreshToken = generateRefreshToken(userId);
 
         return new TokenIssueResponse(accessToken, refreshToken);

--- a/src/test/java/org/cookieandkakao/babting/domain/member/entity/KakaoTokenTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/member/entity/KakaoTokenTest.java
@@ -1,0 +1,28 @@
+package org.cookieandkakao.babting.domain.member.entity;
+
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
+import org.cookieandkakao.babting.domain.member.dto.KakaoTokenGetResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KakaoTokenTest {
+
+    @Test
+    @DisplayName("카카오 접근 토큰을 수정할 수 있다")
+    void updateAccessToken() {
+        // given
+        KakaoToken kakaoToken = new KakaoToken("accessToken", LocalDateTime.now(), "refreshToken",
+            LocalDateTime.now());
+        KakaoTokenGetResponse kakaoTokenDto = new KakaoTokenGetResponse("new accessToken", 100,
+            null, null);
+
+        // when
+        kakaoToken.updateAccessToken(kakaoTokenDto);
+
+        // then
+        Assertions.assertThat(kakaoToken.getAccessToken()).isEqualTo(kakaoTokenDto.accessToken());
+        Assertions.assertThat(kakaoToken.getExpiresAt()).isEqualToIgnoringNanos(LocalDateTime.now().plusSeconds(kakaoTokenDto.expiresIn()));
+    }
+
+}

--- a/src/test/java/org/cookieandkakao/babting/domain/member/entity/MemberTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/member/entity/MemberTest.java
@@ -1,0 +1,44 @@
+package org.cookieandkakao.babting.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.cookieandkakao.babting.domain.member.dto.KakaoMemberProfileGetResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("회원 프로필을 수정할 수 있다")
+    void updateProfile() {
+        // given
+        Member member = new Member(1L);
+        KakaoMemberProfileGetResponse profileDto = new KakaoMemberProfileGetResponse(
+            "nickname", "pfImg.jpg", "tnImg.jpg");
+
+        // when
+        member.updateProfile(profileDto);
+
+        // then
+        assertThat(member.getNickname()).isEqualTo(profileDto.nickname());
+        assertThat(member.getProfileImageUrl()).isEqualTo(profileDto.profileImage());
+        assertThat(member.getThumbnailImageUrl()).isEqualTo(profileDto.thumbnailImage());
+    }
+
+    @Test
+    @DisplayName("회원의 카카오 토큰을 수정할 수 있다")
+    void updateKakaoToken() {
+        // given
+        Member member = new Member(1L);
+        KakaoToken kakaoToken = new KakaoToken("accessToken", LocalDateTime.now(), "refreshToken",
+            LocalDateTime.now());
+
+        // when
+        member.updateKakaoToken(kakaoToken);
+
+        // then
+        assertThat(member.getKakaoToken()).isEqualTo(kakaoToken);
+    }
+
+}


### PR DESCRIPTION
## 주요 변경사항
- RestClientConfig 사용하도록 수정
- accessToken 재발급 기능 구현
- getKakaoAccessToken 메서드 추가
  - 기존 getKakaoToken 메서드 deprecate
  - 카카오 accessToken이 만료됐을 경우 갱신하는 로직 추가
- swagger 설명 추가
- entity 클래스 테스트 코드 작성

## 리뷰어에게...
기존에 KakaoToken을 반환하던 getKakaoToken 메서드를 deprecate 시키고 String 타입의 accessToken만을 반환하는 getKakaoAccessToken 메서드를 추가했습니다. 이 메서드에는 카카오 토큰의 유효기간을 확인하고 만료됐을 경우 재발급받는 로직이 추가되었습니다. 이 메서드를 사용할 수 있도록 기존 코드 수정 부탁드립니다!

## 관련 이슈

closes #

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
