### PR TITLE
[FEAT, TEST, REFACTOR] 리뷰 반영, MeetingEventService 분리, 테스트 코드 작성, CORS 추가, 모임별 개인 일정 조회 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 application-oauth.properties
 application-db.properties
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,8 @@ services:
     container_name: springboot-app
     ports:
       - "8080:8080"
-    environment:
-      - SPRING_DATASOURCE_URL=jdbc:h2:mem:testdb
-      - SPRING_REDIS_HOST=redis
-      - SPRING_REDIS_PORT=6379
+    env_file:
+      - .env
     depends_on:
       - redis
 

--- a/src/main/java/org/cookieandkakao/babting/common/config/WebConfig.java
+++ b/src/main/java/org/cookieandkakao/babting/common/config/WebConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.cookieandkakao.babting.common.resolver.LoginMemberIdArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -18,5 +19,16 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberIdArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE")
+            .allowedHeaders("Content-Type", "Authorization")
+            .exposedHeaders("Authorization", "Location")
+            .maxAge(1800)
+            .allowCredentials(true);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package org.cookieandkakao.babting.common.exception;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseBody.FailureBody;
 import org.cookieandkakao.babting.common.apiresponse.ApiResponseGenerator;
 import org.cookieandkakao.babting.common.exception.customexception.ApiException;
+import org.cookieandkakao.babting.common.exception.customexception.CacheEvictionException;
 import org.cookieandkakao.babting.common.exception.customexception.EventCreationException;
 import org.cookieandkakao.babting.common.exception.customexception.InvalidFoodPreferenceTypeException;
 import org.cookieandkakao.babting.common.exception.customexception.JsonConversionException;
@@ -55,6 +56,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidFoodPreferenceTypeException.class)
     public ResponseEntity<FailureBody> handleInvalidFoodPreferenceTypeException(InvalidFoodPreferenceTypeException ex) {
         return ApiResponseGenerator.fail(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(CacheEvictionException.class)
+    public ResponseEntity<FailureBody> handleCacheEvictionException(CacheEvictionException ex) {
+        return ApiResponseGenerator.fail(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
 
     // 모든 Exception을 처리하는 핸들러

--- a/src/main/java/org/cookieandkakao/babting/common/exception/customexception/CacheEvictionException.java
+++ b/src/main/java/org/cookieandkakao/babting/common/exception/customexception/CacheEvictionException.java
@@ -1,0 +1,8 @@
+package org.cookieandkakao.babting.common.exception.customexception;
+
+public class CacheEvictionException extends RuntimeException {
+    public CacheEvictionException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/TimeGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/dto/response/TimeGetResponse.java
@@ -31,4 +31,13 @@ public record TimeGetResponse(
         return zonedDateTime.toLocalDateTime();
     }
 
+    public static TimeGetResponse from(Time time) {
+        return new TimeGetResponse(
+            time.getStartAt().toString(),
+            time.getEndAt().toString(),
+            time.getTimeZone(),
+            time.isAllDay()
+        );
+    }
+
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/EventService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/EventService.java
@@ -58,4 +58,11 @@ public class EventService {
             }
         }
     }
+
+    @Transactional
+    public Event saveAvoidTimeEvent(Time avoidTime) {
+        Event avoidTimeEvent = new Event(avoidTime);
+        eventRepository.save(avoidTimeEvent);
+        return avoidTimeEvent;
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarService.java
@@ -15,7 +15,6 @@ import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateRespon
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventDetailGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventListGetResponse;
-import org.cookieandkakao.babting.domain.member.entity.KakaoToken;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -29,16 +28,14 @@ public class TalkCalendarService {
 
     private final TalkCalendarClientService talkCalendarClientService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final EventService eventService;
     private final MemberService memberService;
     private final RedisTemplate<String, String> redisTemplate;
     private static final Duration CACHE_DURATION = Duration.ofMinutes(5);
 
-    public TalkCalendarService(EventService eventService,
+    public TalkCalendarService(
         TalkCalendarClientService talkCalendarClientService,
         MemberService memberService,
         RedisTemplate<String, String> redisTemplate) {
-        this.eventService = eventService;
         this.talkCalendarClientService = talkCalendarClientService;
         this.memberService = memberService;
         this.redisTemplate = redisTemplate;
@@ -51,13 +48,15 @@ public class TalkCalendarService {
             try {
                 // JSON 문자열을 List<EventGetResponse> 로 변환
                 // 리스트이므로 TypeReference 사용
-                return objectMapper.readValue(cachedJson, new TypeReference<List<EventGetResponse>>() {});
+                return objectMapper.readValue(cachedJson,
+                    new TypeReference<List<EventGetResponse>>() {
+                    });
             } catch (JsonProcessingException e) {
                 throw new RuntimeException("캐시된 JSON 변환 오류", e);
             }
         }
 
-        String kakaoAccessToken = getKakaoAccessToken(memberId);
+        String kakaoAccessToken = memberService.getKakaoAccessToken(memberId);
         EventListGetResponse eventList = talkCalendarClientService.getEventList(kakaoAccessToken,
             from, to);
         List<EventGetResponse> updatedEvents = new ArrayList<>();
@@ -89,8 +88,9 @@ public class TalkCalendarService {
             }
         }
 
-        String kakaoAccessToken = getKakaoAccessToken(memberId);
-        EventDetailGetResponse eventDetailGetResponse = talkCalendarClientService.getEvent(kakaoAccessToken, eventId);
+        String kakaoAccessToken = memberService.getKakaoAccessToken(memberId);
+        EventDetailGetResponse eventDetailGetResponse = talkCalendarClientService.getEvent(
+            kakaoAccessToken, eventId);
 
         cacheData(cacheKey, eventDetailGetResponse);
         return eventDetailGetResponse;
@@ -99,7 +99,8 @@ public class TalkCalendarService {
     // JSON 변환 후 Redis에 저장
     private void cacheData(String cacheKey, Object data) {
         try {
-            redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(data), CACHE_DURATION);
+            redisTemplate.opsForValue()
+                .set(cacheKey, objectMapper.writeValueAsString(data), CACHE_DURATION);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("JSON 변환 오류", e);
         }
@@ -107,7 +108,7 @@ public class TalkCalendarService {
 
     public EventCreateResponse createEvent(
         EventCreateRequest eventCreateRequest, Long memberId) {
-        String kakaoAccessToken = getKakaoAccessToken(memberId);
+        String kakaoAccessToken = memberService.getKakaoAccessToken(memberId);
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         // event라는 key에 JSON 형태의 데이터를 추가해야 함
         // EventCreateRequestDto를 JSON으로 변환
@@ -130,21 +131,16 @@ public class TalkCalendarService {
         }
     }
 
-    private String getKakaoAccessToken(Long memberId) {
-        KakaoToken kakaoToken = memberService.getKakaoToken(memberId);
-        String kakaoAccessToken = kakaoToken.getAccessToken();
-        return kakaoAccessToken;
-    }
-
     // 키 값에서 memberId가 포함되어 있는 것 삭제
     private void evictMemberCache(Long memberId) {
         String pattern = CacheKeyGenerator.generateEventListPattern(memberId);
         // 패턴과 카운트 설정
         ScanOptions scanOptions = ScanOptions.scanOptions().match(pattern).count(10).build();
         // 스캔 시작
-        Cursor<byte[]> cursor = redisTemplate.executeWithStickyConnection(connection -> connection.scan(scanOptions));
+        Cursor<byte[]> cursor = redisTemplate.executeWithStickyConnection(
+            connection -> connection.scan(scanOptions));
 
-        while(cursor != null && cursor.hasNext()) {
+        while (cursor != null && cursor.hasNext()) {
             String key = new String(cursor.next());
             redisTemplate.delete(key);
         }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodService.java
@@ -33,9 +33,4 @@ public class FoodService {
             .map(food -> new FoodGetResponse(food.getFoodId(), category.getName(), food.getName()))
             .collect(Collectors.toList());
     }
-
-    public Food findByFoodId(Long foodId) {
-        return foodRepository.findById(foodId)
-            .orElseThrow(() -> new NoSuchElementException("해당 음식 ID가 존재하지 않습니다."));
-    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/food/service/FoodService.java
@@ -1,7 +1,9 @@
 package org.cookieandkakao.babting.domain.food.service;
 
+import java.util.NoSuchElementException;
 import org.cookieandkakao.babting.common.exception.customexception.FoodNotFoundException;
 import org.cookieandkakao.babting.domain.food.dto.FoodGetResponse;
+import org.cookieandkakao.babting.domain.food.entity.Food;
 import org.cookieandkakao.babting.domain.food.entity.FoodCategory;
 import org.cookieandkakao.babting.domain.food.repository.FoodCategoryRepository;
 import org.cookieandkakao.babting.domain.food.repository.FoodRepository;
@@ -16,18 +18,24 @@ public class FoodService {
     private final FoodRepository foodRepository;
     private final FoodCategoryRepository foodCategoryRepository;
 
-    public FoodService(FoodRepository foodRepository, FoodCategoryRepository foodCategoryRepository) {
+    public FoodService(FoodRepository foodRepository,
+        FoodCategoryRepository foodCategoryRepository) {
         this.foodRepository = foodRepository;
         this.foodCategoryRepository = foodCategoryRepository;
     }
 
     public List<FoodGetResponse> getFoodsByCategory(String categoryName) {
         FoodCategory category = foodCategoryRepository.findByName(categoryName)
-                .orElseThrow(() -> new FoodNotFoundException("해당 카테고리가 존재하지 않습니다."));
+            .orElseThrow(() -> new FoodNotFoundException("해당 카테고리가 존재하지 않습니다."));
 
         return foodRepository.findByFoodCategory(category)
-                .stream()
-                .map(food -> new FoodGetResponse(food.getFoodId(), category.getName(), food.getName()))
-                .collect(Collectors.toList());
+            .stream()
+            .map(food -> new FoodGetResponse(food.getFoodId(), category.getName(), food.getName()))
+            .collect(Collectors.toList());
+    }
+
+    public Food findByFoodId(Long foodId) {
+        return foodRepository.findById(foodId)
+            .orElseThrow(() -> new NoSuchElementException("해당 음식 ID가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -11,11 +11,11 @@ import org.cookieandkakao.babting.domain.food.service.MeetingFoodPreferenceUpdat
 import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingJoinCreateRequest;
-import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingGetResponse;
 import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingHostCheckResponse;
 import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingInfoGetResponse;
 import org.cookieandkakao.babting.domain.meeting.dto.response.TimeAvailableGetResponse;
+import org.cookieandkakao.babting.domain.meeting.service.MeetingEventCreateService;
 import org.cookieandkakao.babting.domain.meeting.service.MeetingEventService;
 import org.cookieandkakao.babting.domain.meeting.service.MeetingService;
 import org.springframework.http.HttpStatus;
@@ -36,13 +36,16 @@ public class MeetingController {
     private final MeetingService meetingService;
     private final MeetingEventService meetingEventService;
     private final MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater;
+    private final MeetingEventCreateService meetingEventCreateService;
 
     public MeetingController(MeetingService meetingService,
         MeetingEventService meetingEventService,
-        MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater) {
+        MeetingFoodPreferenceUpdater meetingFoodPreferenceUpdater,
+        MeetingEventCreateService meetingEventCreateService) {
         this.meetingService = meetingService;
         this.meetingEventService = meetingEventService;
         this.meetingFoodPreferenceUpdater = meetingFoodPreferenceUpdater;
+        this.meetingEventCreateService = meetingEventCreateService;
     }
 
     // 모임 생성(주최자)
@@ -66,7 +69,7 @@ public class MeetingController {
         @RequestBody MeetingJoinCreateRequest meetingJoinCreateRequest
     ) {
         meetingService.joinMeeting(memberId, meetingId);
-        meetingEventService.saveMeetingAvoidTime(memberId, meetingId,
+        meetingEventCreateService.saveMeetingAvoidTime(memberId, meetingId,
             meetingJoinCreateRequest.times());
         meetingFoodPreferenceUpdater.updatePreferences(meetingId, memberId,
             meetingJoinCreateRequest.preferences(), meetingJoinCreateRequest.nonPreferences());

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package org.cookieandkakao.babting.domain.meeting.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingJoinCreateRe
 import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingGetResponse;
 import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingHostCheckResponse;
 import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingInfoGetResponse;
+import org.cookieandkakao.babting.domain.meeting.dto.response.MeetingPersonalEventGetResponse;
 import org.cookieandkakao.babting.domain.meeting.dto.response.TimeAvailableGetResponse;
 import org.cookieandkakao.babting.domain.meeting.service.MeetingEventCreateService;
 import org.cookieandkakao.babting.domain.meeting.service.MeetingEventService;
@@ -150,4 +152,16 @@ public class MeetingController {
             timeAvailableGetResponse);
     }
     // 모임 정보 수정
+
+    // 모임별 개인 일정 조회
+    @GetMapping("/{meetingId}/personal-event")
+    @Operation(summary = "모임별 개인 일정 조회", description = "모임에 참가할 때 추가한 모임별 개인 일정을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임별 개인 일정 조회 성공")
+    public ResponseEntity<SuccessBody<MeetingPersonalEventGetResponse>> getPersonalEvent(
+        @Parameter(description = "모임별 개인 일정 조회를 위한 모임 ID", required = true) @PathVariable("meetingId") Long meetingId,
+        @LoginMemberId Long memberId
+    ) {
+        MeetingPersonalEventGetResponse meetingPersonalEventGetResponse = meetingEventService.findMeetingPersonalEvent(meetingId, memberId);
+        return ApiResponseGenerator.success(HttpStatus.OK, "모임별 개인 일정 조회 성공", meetingPersonalEventGetResponse);
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/request/MeetingJoinCreateRequest.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/request/MeetingJoinCreateRequest.java
@@ -3,6 +3,8 @@ package org.cookieandkakao.babting.domain.meeting.dto.request;
 import java.util.List;
 
 public record MeetingJoinCreateRequest(
+    List<Long> preferences,
+    List<Long> nonPreferences,
     List<MeetingTimeCreateRequest> times
 ) {
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/response/MeetingPersonalEventGetResponse.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/dto/response/MeetingPersonalEventGetResponse.java
@@ -1,0 +1,10 @@
+package org.cookieandkakao.babting.domain.meeting.dto.response;
+
+import java.util.List;
+import org.cookieandkakao.babting.domain.calendar.dto.response.TimeGetResponse;
+
+public record MeetingPersonalEventGetResponse(
+    List<TimeGetResponse> meetingPersonalTimes
+) {
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/MeetingEvent.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/entity/MeetingEvent.java
@@ -34,4 +34,8 @@ public class MeetingEvent {
         this.memberMeeting = memberMeeting;
         this.event = event;
     }
+
+    public Event getEvent() {
+        return event;
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MeetingEventRepository.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/repository/MeetingEventRepository.java
@@ -1,5 +1,6 @@
 package org.cookieandkakao.babting.domain.meeting.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
 import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeetingEventRepository extends JpaRepository<MeetingEvent, Long> {
-    Optional<MeetingEvent> findByMemberMeeting(MemberMeeting memberMeeting);
+    List<MeetingEvent> findByMemberMeeting(MemberMeeting memberMeeting);
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateService.java
@@ -1,0 +1,89 @@
+package org.cookieandkakao.babting.domain.meeting.service;
+
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
+import org.cookieandkakao.babting.domain.calendar.dto.request.TimeCreateRequest;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
+import org.cookieandkakao.babting.domain.calendar.entity.Event;
+import org.cookieandkakao.babting.domain.calendar.service.EventService;
+import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
+import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
+import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
+import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
+import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
+import org.springframework.stereotype.Service;
+
+@Transactional
+@Service
+public class MeetingEventCreateService {
+
+    private final TalkCalendarService talkCalendarService;
+    private final EventService eventService;
+    private final MemberService memberService;
+    private final MeetingService meetingService;
+    private final MeetingEventService meetingEventService;
+    private static final String TIME_ZONE = "Asia/Seoul";
+
+    public MeetingEventCreateService(TalkCalendarService talkCalendarService,
+        EventService eventService, MemberService memberService,
+        MeetingService meetingService, MeetingEventService meetingEventService) {
+        this.talkCalendarService = talkCalendarService;
+        this.eventService = eventService;
+        this.memberService = memberService;
+        this.meetingService = meetingService;
+        this.meetingEventService = meetingEventService;
+    }
+
+    // 일정 생성 후 캘린더에 일정 추가
+    public EventCreateResponse addMeetingEvent(Long memberId,
+        MeetingEventCreateRequest meetingEventCreateRequest) {
+        EventCreateRequest eventCreateRequest = convertToEventCreateRequest(
+            meetingEventCreateRequest);
+        return talkCalendarService.createEvent(eventCreateRequest, memberId);
+    }
+
+    private EventCreateRequest convertToEventCreateRequest(
+        MeetingEventCreateRequest meetingEventCreateRequest) {
+        return new EventCreateRequest(
+            meetingEventCreateRequest.title(),
+            meetingEventCreateRequest.time().toTimeCreateRequest(), null,
+            meetingEventCreateRequest.reminders(), null);
+    }
+
+    // 모임별 개인적으로 피하고 싶은 시간 저장하기
+    @Transactional
+    public void saveMeetingAvoidTime(Long memberId, Long meetingId,
+        List<MeetingTimeCreateRequest> avoidTimeCreateRequests) {
+
+        // 피하고 싶은 시간 없으면 그냥 종료
+        if (avoidTimeCreateRequests.isEmpty() || avoidTimeCreateRequests == null) {
+            return;
+        }
+
+        Member member = memberService.findMember(memberId);
+        Meeting meeting = meetingService.findMeeting(meetingId);
+        MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
+
+        for (MeetingTimeCreateRequest avoidTimeCreateRequest : avoidTimeCreateRequests) {
+            createAndSaveMeetingEvent(memberMeeting, avoidTimeCreateRequest);
+        }
+    }
+
+    // 피하고 싶은 시간을 기반으로 MeetingEvent 생성 및 저장
+    private void createAndSaveMeetingEvent(MemberMeeting memberMeeting,
+        MeetingTimeCreateRequest meetingTimeCreateRequest) {
+        // 시간 정보를 Event로 생성 후 저장
+        TimeCreateRequest timeCreateRequest = meetingTimeCreateRequest.toTimeCreateRequest();
+        Event avoidEvent = eventService.saveAvoidTimeEvent(timeCreateRequest.toEntity());
+
+        // MeetingEvent로 저장
+        MeetingEvent meetingEvent = new MeetingEvent(memberMeeting, avoidEvent);
+        meetingEventService.saveMeetingEvent(meetingEvent);
+    }
+
+
+}

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateService.java
@@ -13,6 +13,7 @@ import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRe
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
 import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
 import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
+import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
@@ -25,17 +26,18 @@ public class MeetingEventCreateService {
     private final EventService eventService;
     private final MemberService memberService;
     private final MeetingService meetingService;
-    private final MeetingEventService meetingEventService;
+    private final MeetingEventRepository meetingEventRepository;
     private static final String TIME_ZONE = "Asia/Seoul";
 
     public MeetingEventCreateService(TalkCalendarService talkCalendarService,
         EventService eventService, MemberService memberService,
-        MeetingService meetingService, MeetingEventService meetingEventService) {
+        MeetingService meetingService,
+        MeetingEventRepository meetingEventRepository) {
         this.talkCalendarService = talkCalendarService;
         this.eventService = eventService;
         this.memberService = memberService;
         this.meetingService = meetingService;
-        this.meetingEventService = meetingEventService;
+        this.meetingEventRepository = meetingEventRepository;
     }
 
     // 일정 생성 후 캘린더에 일정 추가
@@ -82,7 +84,11 @@ public class MeetingEventCreateService {
 
         // MeetingEvent로 저장
         MeetingEvent meetingEvent = new MeetingEvent(memberMeeting, avoidEvent);
-        meetingEventService.saveMeetingEvent(meetingEvent);
+        saveMeetingEvent(meetingEvent);
+    }
+
+    private void saveMeetingEvent(MeetingEvent meetingEvent) {
+        meetingEventRepository.save(meetingEvent);
     }
 
 

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventService.java
@@ -10,8 +10,7 @@ import java.util.List;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.TimeGetResponse;
 import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
-import org.cookieandkakao.babting.domain.food.repository.FoodRepository;
-import org.cookieandkakao.babting.domain.food.service.FoodService;
+import org.cookieandkakao.babting.domain.food.service.FoodRepositoryService;
 import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRequest;
@@ -30,12 +29,13 @@ public class MeetingEventService {
     private final MemberService memberService;
     private final TalkCalendarService talkCalendarService;
     private final MeetingService meetingService;
-    private static final String TIME_ZONE = "Asia/Seoul";
-    private static final List<Integer> DEFAULT_REMINDER_TIMES = List.of(15, 30);
     private final MeetingValidationService meetingValidationService;
     private final MeetingEventCreateService meetingEventCreateService;
     private final MeetingEventRepository meetingEventRepository;
-    private final FoodService foodService;
+    private final FoodRepositoryService foodRepositoryService;
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final List<Integer> DEFAULT_REMINDER_TIMES = List.of(15, 30);
 
     public MeetingEventService(MemberService memberService,
         TalkCalendarService talkCalendarService,
@@ -43,14 +43,14 @@ public class MeetingEventService {
         MeetingValidationService meetingValidationService,
         MeetingEventCreateService meetingEventCreateService,
         MeetingEventRepository meetingEventRepository,
-        FoodService foodService) {
+        FoodRepositoryService foodRepositoryService) {
         this.memberService = memberService;
         this.talkCalendarService = talkCalendarService;
         this.meetingService = meetingService;
         this.meetingValidationService = meetingValidationService;
         this.meetingEventCreateService = meetingEventCreateService;
         this.meetingEventRepository = meetingEventRepository;
-        this.foodService = foodService;
+        this.foodRepositoryService = foodRepositoryService;
     }
 
     // 모임 확정
@@ -64,7 +64,7 @@ public class MeetingEventService {
         meetingValidationService.validateMeetingConfirmation(meeting);
 
         meeting.confirmDateTime(confirmMeetingGetRequest.confirmDateTime());
-        meeting.confirmFood(foodService.findByFoodId(foodId));
+        meeting.confirmFood(foodRepositoryService.findFoodById(foodId));
 
         MeetingTimeCreateRequest meetingTimeCreateRequest = createMeetingTimeRequest(meeting);
         MeetingEventCreateRequest meetingEventCreateRequest = createMeetingEventRequest(meeting,

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventService.java
@@ -16,8 +16,6 @@ import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateR
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.response.TimeAvailableGetResponse;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
-import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
-import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
@@ -31,7 +29,6 @@ public class MeetingEventService {
     private final MeetingService meetingService;
     private final MeetingValidationService meetingValidationService;
     private final MeetingEventCreateService meetingEventCreateService;
-    private final MeetingEventRepository meetingEventRepository;
     private final FoodRepositoryService foodRepositoryService;
 
     private static final String TIME_ZONE = "Asia/Seoul";
@@ -42,14 +39,12 @@ public class MeetingEventService {
         MeetingService meetingService,
         MeetingValidationService meetingValidationService,
         MeetingEventCreateService meetingEventCreateService,
-        MeetingEventRepository meetingEventRepository,
         FoodRepositoryService foodRepositoryService) {
         this.memberService = memberService;
         this.talkCalendarService = talkCalendarService;
         this.meetingService = meetingService;
         this.meetingValidationService = meetingValidationService;
         this.meetingEventCreateService = meetingEventCreateService;
-        this.meetingEventRepository = meetingEventRepository;
         this.foodRepositoryService = foodRepositoryService;
     }
 
@@ -219,9 +214,5 @@ public class MeetingEventService {
         }
 
         return availableTimes;
-    }
-
-    public void saveMeetingEvent(MeetingEvent meetingEvent) {
-        meetingEventRepository.save(meetingEvent);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventService.java
@@ -1,7 +1,5 @@
 package org.cookieandkakao.babting.domain.meeting.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -9,26 +7,18 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import org.cookieandkakao.babting.common.exception.customexception.JsonConversionException;
-import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
-import org.cookieandkakao.babting.domain.calendar.dto.request.TimeCreateRequest;
-import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.TimeGetResponse;
-import org.cookieandkakao.babting.domain.calendar.entity.Event;
-import org.cookieandkakao.babting.domain.calendar.repository.EventRepository;
-import org.cookieandkakao.babting.domain.calendar.service.EventService;
-import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarClientService;
 import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
+import org.cookieandkakao.babting.domain.food.repository.FoodRepository;
+import org.cookieandkakao.babting.domain.food.service.FoodService;
 import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.response.TimeAvailableGetResponse;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
 import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
-import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
 import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventRepository;
-import org.cookieandkakao.babting.domain.member.entity.KakaoToken;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
@@ -39,55 +29,51 @@ public class MeetingEventService {
 
     private final MemberService memberService;
     private final TalkCalendarService talkCalendarService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final MeetingService meetingService;
     private static final String TIME_ZONE = "Asia/Seoul";
     private static final List<Integer> DEFAULT_REMINDER_TIMES = List.of(15, 30);
+    private final MeetingValidationService meetingValidationService;
+    private final MeetingEventCreateService meetingEventCreateService;
     private final MeetingEventRepository meetingEventRepository;
-    private final EventService eventService;
+    private final FoodService foodService;
 
     public MeetingEventService(MemberService memberService,
         TalkCalendarService talkCalendarService,
         MeetingService meetingService,
-        MeetingEventRepository meetingEventRepository, EventService eventService) {
+        MeetingValidationService meetingValidationService,
+        MeetingEventCreateService meetingEventCreateService,
+        MeetingEventRepository meetingEventRepository,
+        FoodService foodService) {
         this.memberService = memberService;
         this.talkCalendarService = talkCalendarService;
         this.meetingService = meetingService;
+        this.meetingValidationService = meetingValidationService;
+        this.meetingEventCreateService = meetingEventCreateService;
         this.meetingEventRepository = meetingEventRepository;
-        this.eventService = eventService;
+        this.foodService = foodService;
     }
 
-    // 모임 확정되면 일정 생성
+    // 모임 확정
     public void confirmMeeting(Long memberId, Long meetingId,
         ConfirmMeetingGetRequest confirmMeetingGetRequest) {
         Member member = memberService.findMember(memberId);
         Meeting meeting = meetingService.findMeeting(meetingId);
-        validateHostPermission(member, meeting);
-        validateMeetingConfirmation(meeting);
+        Long foodId = confirmMeetingGetRequest.confirmFoodId();
+
+        meetingValidationService.validateHostPermission(member, meeting);
+        meetingValidationService.validateMeetingConfirmation(meeting);
 
         meeting.confirmDateTime(confirmMeetingGetRequest.confirmDateTime());
+        meeting.confirmFood(foodService.findByFoodId(foodId));
 
         MeetingTimeCreateRequest meetingTimeCreateRequest = createMeetingTimeRequest(meeting);
         MeetingEventCreateRequest meetingEventCreateRequest = createMeetingEventRequest(meeting,
             meetingTimeCreateRequest);
 
-        List<Long> memberIds = getMemberIdInMeetingId(meetingId);
+        List<Long> memberIds = meetingService.getMemberIdInMeetingId(meetingId);
 
         for (Long currentMemberId : memberIds) {
-            addMeetingEvent(currentMemberId, meetingEventCreateRequest);
-        }
-    }
-
-    private void validateHostPermission(Member member, Meeting meeting) {
-        MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
-        if (!memberMeeting.isHost()) {
-            throw new IllegalStateException("권한이 없습니다.");
-        }
-    }
-
-    private void validateMeetingConfirmation(Meeting meeting) {
-        if (meeting.getConfirmDateTime() != null) {
-            throw new IllegalStateException("이미 모임 시간이 확정되었습니다.");
+            meetingEventCreateService.addMeetingEvent(currentMemberId, meetingEventCreateRequest);
         }
     }
 
@@ -105,44 +91,6 @@ public class MeetingEventService {
             DEFAULT_REMINDER_TIMES);
     }
 
-    // 일정 생성 후 캘린더에 일정 추가
-    public EventCreateResponse addMeetingEvent(Long memberId,
-        MeetingEventCreateRequest meetingEventCreateRequest) {
-        EventCreateRequest eventCreateRequest = convertToEventCreateRequest(
-            meetingEventCreateRequest);
-        return talkCalendarService.createEvent(eventCreateRequest, memberId);
-    }
-
-    private EventCreateRequest convertToEventCreateRequest(
-        MeetingEventCreateRequest meetingEventCreateRequest) {
-        return new EventCreateRequest(
-            meetingEventCreateRequest.title(),
-            meetingEventCreateRequest.time().toTimeCreateRequest(), null,
-            meetingEventCreateRequest.reminders(), null);
-    }
-
-    private String getKakaoAccessToken(Long memberId) {
-        KakaoToken kakaoToken = memberService.getKakaoToken(memberId);
-        return kakaoToken.getAccessToken();
-    }
-
-    private String convertToJSONString(MeetingEventCreateRequest eventCreateRequest) {
-        try {
-            return objectMapper.writeValueAsString(eventCreateRequest);
-        } catch (JsonProcessingException e) {
-            throw new JsonConversionException("JSON 변환 중 오류가 발생했습니다.");
-        }
-    }
-
-    private List<Long> getMemberIdInMeetingId(Long meetingId) {
-        Meeting meeting = meetingService.findMeeting(meetingId);
-        List<MemberMeeting> memberMeetings = meetingService.findAllMemberMeeting(meeting);
-
-        return memberMeetings.stream()
-            .map(memberMeeting -> memberMeeting.getMember().getMemberId())
-            .toList();
-    }
-
     /**
      * 빈 시간대 조회 로직 설명
      * <p>
@@ -153,7 +101,7 @@ public class MeetingEventService {
      * mergedTime에 있는 시간들을 순회하면서 i번째 끝 시간 ~ i+1번째 시작 시간으로 시간 생성
      */
     public TimeAvailableGetResponse findAvailableTime(Long meetingId) {
-        List<Long> joinedMemberIds = getMemberIdInMeetingId(meetingId);
+        List<Long> joinedMemberIds = meetingService.getMemberIdInMeetingId(meetingId);
         Meeting meeting = meetingService.findMeeting(meetingId);
         String from = meeting.getStartDate().toString();
         String to = meeting.getEndDate().toString();
@@ -273,39 +221,7 @@ public class MeetingEventService {
         return availableTimes;
     }
 
-
-    // 모임별 개인적으로 피하고 싶은 시간 저장하기
-    @Transactional
-    public void saveMeetingAvoidTime(Long memberId, Long meetingId,
-        List<MeetingTimeCreateRequest> avoidTimeCreateRequests) {
-
-        // 피하고 싶은 시간 없으면 그냥 종료
-        if (avoidTimeCreateRequests.isEmpty() || avoidTimeCreateRequests == null) {
-            return;
-        }
-
-        Member member = memberService.findMember(memberId);
-        Meeting meeting = meetingService.findMeeting(meetingId);
-        MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
-
-        for (MeetingTimeCreateRequest avoidTimeCreateRequest : avoidTimeCreateRequests) {
-            createAndSaveMeetingEvent(memberMeeting, avoidTimeCreateRequest);
-        }
-    }
-
-    // 피하고 싶은 시간을 기반으로 MeetingEvent 생성 및 저장
-    private void createAndSaveMeetingEvent(MemberMeeting memberMeeting,
-        MeetingTimeCreateRequest meetingTimeCreateRequest) {
-        // 시간 정보를 Event로 생성 후 저장
-        TimeCreateRequest timeCreateRequest = meetingTimeCreateRequest.toTimeCreateRequest();
-        Event avoidEvent = eventService.saveAvoidTimeEvent(timeCreateRequest.toEntity());
-
-        // MeetingEvent로 저장
-        MeetingEvent meetingEvent = new MeetingEvent(memberMeeting, avoidEvent);
-        saveMeetingEvent(meetingEvent);
-    }
-
-    private void saveMeetingEvent(MeetingEvent meetingEvent) {
+    public void saveMeetingEvent(MeetingEvent meetingEvent) {
         meetingEventRepository.save(meetingEvent);
     }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingService.java
@@ -112,4 +112,13 @@ public class MeetingService {
     public List<MemberMeeting> findAllMemberMeeting(Meeting meeting){
         return memberMeetingRepository.findByMeeting(meeting);
     }
+
+    public List<Long> getMemberIdInMeetingId(Long meetingId) {
+        Meeting meeting = findMeeting(meetingId);
+        List<MemberMeeting> memberMeetings = findAllMemberMeeting(meeting);
+
+        return memberMeetings.stream()
+            .map(memberMeeting -> memberMeeting.getMember().getMemberId())
+            .toList();
+    }
 }

--- a/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingValidationService.java
+++ b/src/main/java/org/cookieandkakao/babting/domain/meeting/service/MeetingValidationService.java
@@ -1,0 +1,30 @@
+package org.cookieandkakao.babting.domain.meeting.service;
+
+import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
+import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
+import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MeetingValidationService {
+
+    private final MeetingService meetingService;
+
+    public MeetingValidationService(MeetingService meetingService) {
+        this.meetingService = meetingService;
+    }
+
+    public void validateHostPermission(Member member, Meeting meeting) {
+        MemberMeeting memberMeeting = meetingService.findMemberMeeting(member, meeting);
+        if (!memberMeeting.isHost()) {
+            throw new IllegalStateException("권한이 없습니다.");
+        }
+    }
+
+    public void validateMeetingConfirmation(Meeting meeting) {
+        if (meeting.getConfirmDateTime() != null) {
+            throw new IllegalStateException("이미 모임 시간이 확정되었습니다.");
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,5 +2,17 @@ spring.application.name=babting
 spring.profiles.active=oauth,db
 
 spring.cache.type=redis
-spring.data.redis.host=localhost
+spring.data.redis.host=redis
 spring.data.redis.port=6379
+
+# My sql
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+
+# hibernate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.show_sql=true

--- a/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/calendar/service/TalkCalendarServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +22,6 @@ import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateRespon
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventDetailGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventGetResponse;
 import org.cookieandkakao.babting.domain.calendar.dto.response.EventListGetResponse;
-import org.cookieandkakao.babting.domain.member.entity.KakaoToken;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,8 +79,7 @@ class TalkCalendarServiceTest {
         EventDetailGetResponse eventDetailGetResponseMock = new EventDetailGetResponse(
             eventGetResponse);
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.getEventList(accessToken, from, to)).willReturn(
             eventListGetResponse);
         given(talkCalendarClientService.getEvent(accessToken, eventGetResponse.id())).willReturn(
@@ -92,12 +89,12 @@ class TalkCalendarServiceTest {
         List<EventGetResponse> result = talkCalendarService.getUpdatedEventList(from, to, memberId);
 
         // Then
-        verify(memberService).getKakaoToken(any(Long.class));
+        verify(memberService).getKakaoAccessToken(memberId);
         verify(talkCalendarClientService).getEventList(accessToken, from, to);
         verify(talkCalendarClientService).getEvent(accessToken, eventGetResponse.id());
         assertNotNull(result);
         assertEquals(1, result.size());
-        assertEquals("testId", result.get(0).id());
+        assertEquals("testId", result.getFirst().id());
     }
 
     @Test
@@ -113,8 +110,7 @@ class TalkCalendarServiceTest {
             eventGetResponse);
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.getEvent(accessToken, eventId)).willReturn(
             eventDetailGetResponseMock);
 
@@ -122,7 +118,7 @@ class TalkCalendarServiceTest {
         EventDetailGetResponse result = talkCalendarService.getEvent(memberId, eventId);
 
         // Then
-        verify(memberService).getKakaoToken(any(Long.class));
+        verify(memberService).getKakaoAccessToken(any(Long.class));
         verify(talkCalendarClientService).getEvent(accessToken, eventId);
         assertNotNull(result);
         assertEquals(eventId, result.event().id());
@@ -144,8 +140,7 @@ class TalkCalendarServiceTest {
         EventCreateResponse responseBody = new EventCreateResponse(eventId);
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.createEvent(accessToken, formData)).willReturn(
             responseBody);
 
@@ -153,7 +148,7 @@ class TalkCalendarServiceTest {
         EventCreateResponse result = talkCalendarService.createEvent(eventCreateRequest, memberId);
 
         // Then
-        verify(memberService).getKakaoToken(any(Long.class));
+        verify(memberService).getKakaoAccessToken(any(Long.class));
         verify(talkCalendarClientService).createEvent(accessToken, formData);
         assertNotNull(result);
         assertEquals(eventId, result.eventId());
@@ -166,7 +161,7 @@ class TalkCalendarServiceTest {
         String eventId = "testId";
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willThrow(
+        given(memberService.getKakaoAccessToken(memberId)).willThrow(
             new IllegalArgumentException("존재하지 않는 MemberID입니다."));
 
         // When
@@ -176,7 +171,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "존재하지 않는 MemberID입니다.");
-        verify(memberService).getKakaoToken(memberId);
+        verify(memberService).getKakaoAccessToken(memberId);
     }
 
     @Test
@@ -187,8 +182,7 @@ class TalkCalendarServiceTest {
         String accessToken = "testAccessToken";
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.getEvent(accessToken, eventId)).willThrow(
             new IllegalArgumentException("존재하지 않는 EventID입니다."));
 
@@ -199,7 +193,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "존재하지 않는 EventID입니다.");
-        verify(memberService).getKakaoToken(memberId);
+        verify(memberService).getKakaoAccessToken(memberId);
         verify(talkCalendarClientService).getEvent(accessToken, eventId);
     }
 
@@ -211,7 +205,7 @@ class TalkCalendarServiceTest {
         String to = "2024-10-31T23:59:59Z";
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willThrow(
+        given(memberService.getKakaoAccessToken(memberId)).willThrow(
             new IllegalArgumentException("존재하지 않는 MemberID입니다."));
 
         // When
@@ -221,7 +215,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "존재하지 않는 MemberID입니다.");
-        verify(memberService).getKakaoToken(memberId);
+        verify(memberService).getKakaoAccessToken(memberId);
     }
 
     @Test
@@ -233,8 +227,7 @@ class TalkCalendarServiceTest {
         String accessToken = "testAccessToken";
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.getEventList(accessToken, from, to)).willThrow(
             new IllegalArgumentException("잘못된 From 값 입니다."));
 
@@ -245,7 +238,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "잘못된 From 값 입니다.");
-        verify(memberService).getKakaoToken(any(Long.class));
+        verify(memberService).getKakaoAccessToken(any(Long.class));
         verify(talkCalendarClientService).getEventList(accessToken, from, to);
     }
 
@@ -258,8 +251,7 @@ class TalkCalendarServiceTest {
         String accessToken = "testAccessToken";
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.getEventList(accessToken, from, to)).willThrow(
             new IllegalArgumentException("잘못된 To 값 입니다."));
 
@@ -270,7 +262,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "잘못된 To 값 입니다.");
-        verify(memberService).getKakaoToken(any(Long.class));
+        verify(memberService).getKakaoAccessToken(any(Long.class));
         verify(talkCalendarClientService).getEventList(accessToken, from, to);
     }
 
@@ -290,8 +282,7 @@ class TalkCalendarServiceTest {
             eventGetResponse);
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.getEventList(accessToken, from, to)).willReturn(
             eventListGetResponse);
         given(talkCalendarClientService.getEvent(accessToken, eventGetResponse.id())).willThrow(
@@ -304,7 +295,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "존재하지 않는 EventID입니다.");
-        verify(memberService).getKakaoToken(any(Long.class));
+        verify(memberService).getKakaoAccessToken(any(Long.class));
         verify(talkCalendarClientService).getEventList(accessToken, from, to);
         verify(talkCalendarClientService).getEvent(accessToken, eventGetResponse.id());
     }
@@ -323,8 +314,7 @@ class TalkCalendarServiceTest {
         EventCreateResponse responseBody = new EventCreateResponse(eventId);
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willReturn(
-            new KakaoToken(accessToken, null, null, null));
+        given(memberService.getKakaoAccessToken(memberId)).willReturn(accessToken);
         given(talkCalendarClientService.createEvent(accessToken, formData)).willThrow(
             new EventCreationException("EventCreateRequest 에러"));
 
@@ -335,7 +325,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), EventCreationException.class);
         assertEquals(e.getMessage(), "EventCreateRequest 에러");
-        verify(memberService).getKakaoToken(memberId);
+        verify(memberService).getKakaoAccessToken(memberId);
         verify(talkCalendarClientService).createEvent(accessToken, formData);
     }
 
@@ -346,7 +336,7 @@ class TalkCalendarServiceTest {
         EventCreateRequest eventCreateRequestMcok = mock(EventCreateRequest.class);
 
         // Mocking
-        given(memberService.getKakaoToken(memberId)).willThrow(
+        given(memberService.getKakaoAccessToken(memberId)).willThrow(
             new IllegalArgumentException("존재하지 않는 MemberID입니다."));
 
         // When
@@ -356,7 +346,7 @@ class TalkCalendarServiceTest {
         // Then
         assertEquals(e.getClass(), IllegalArgumentException.class);
         assertEquals(e.getMessage(), "존재하지 않는 MemberID입니다.");
-        verify(memberService).getKakaoToken(memberId);
+        verify(memberService).getKakaoAccessToken(memberId);
     }
 
 }

--- a/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateServiceTest.java
@@ -22,6 +22,7 @@ import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRe
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
 import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
 import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
+import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,7 @@ class MeetingEventCreateServiceTest {
     @Mock
     private MeetingService meetingService;
     @Mock
-    private MeetingEventService meetingEventService;
+    private MeetingEventRepository meetingEventRepository;
 
     @InjectMocks
     private MeetingEventCreateService meetingEventCreateService;
@@ -75,6 +76,7 @@ class MeetingEventCreateServiceTest {
         assertEquals(result.eventId(), expectedResponse.eventId());
         verify(talkCalendarService).createEvent(any(EventCreateRequest.class), eq(memberId));
     }
+
 
     @Test
     void saveMeetingAvoidTime_NoAvoidTime() {
@@ -114,7 +116,7 @@ class MeetingEventCreateServiceTest {
 
         // Then
         verify(eventService).saveAvoidTimeEvent(time);
-        verify(meetingEventService).saveMeetingEvent(any(MeetingEvent.class));
+        verify(meetingEventRepository).save(any(MeetingEvent.class));
     }
 
     @Test

--- a/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventCreateServiceTest.java
@@ -1,0 +1,162 @@
+package org.cookieandkakao.babting.domain.meeting.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.cookieandkakao.babting.domain.calendar.dto.request.EventCreateRequest;
+import org.cookieandkakao.babting.domain.calendar.dto.request.TimeCreateRequest;
+import org.cookieandkakao.babting.domain.calendar.dto.response.EventCreateResponse;
+import org.cookieandkakao.babting.domain.calendar.entity.Event;
+import org.cookieandkakao.babting.domain.calendar.entity.Time;
+import org.cookieandkakao.babting.domain.calendar.service.EventService;
+import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
+import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingTimeCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
+import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
+import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
+import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MeetingEventCreateServiceTest {
+
+    @Mock
+    private TalkCalendarService talkCalendarService;
+    @Mock
+    private EventService eventService;
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private MeetingService meetingService;
+    @Mock
+    private MeetingEventService meetingEventService;
+
+    @InjectMocks
+    private MeetingEventCreateService meetingEventCreateService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void addMeetingEvent() {
+        // Given
+        Long memberId = 1L;
+        MeetingEventCreateRequest meetingEventCreateRequest = mock(MeetingEventCreateRequest.class);
+        MeetingTimeCreateRequest meetingTimeCreateRequest = mock(MeetingTimeCreateRequest.class);
+        TimeCreateRequest timeCreateRequest = mock(TimeCreateRequest.class);
+        EventCreateResponse expectedResponse = mock(EventCreateResponse.class);
+
+        // Mocking
+        given(meetingEventCreateRequest.title()).willReturn("Meeting Title");
+        given(meetingEventCreateRequest.time()).willReturn(meetingTimeCreateRequest);
+        given(meetingTimeCreateRequest.toTimeCreateRequest()).willReturn(timeCreateRequest);
+        given(talkCalendarService.createEvent(any(EventCreateRequest.class), eq(memberId)))
+            .willReturn(expectedResponse);
+
+        // When
+        EventCreateResponse result = meetingEventCreateService.addMeetingEvent(memberId, meetingEventCreateRequest);
+
+        // Then
+        assertEquals(expectedResponse, result);
+        assertEquals(result.eventId(), expectedResponse.eventId());
+        verify(talkCalendarService).createEvent(any(EventCreateRequest.class), eq(memberId));
+    }
+
+    @Test
+    void saveMeetingAvoidTime_NoAvoidTime() {
+        // Given
+        Long memberId = 1L;
+        Long meetingId = 2L;
+        List<MeetingTimeCreateRequest> emptyAvoidTimeRequests = List.of();
+
+        // When & Then
+        assertDoesNotThrow(() -> meetingEventCreateService.saveMeetingAvoidTime(memberId, meetingId, emptyAvoidTimeRequests));
+    }
+
+    @Test
+    void saveMeetingAvoidTime_AvoidTime() {
+        // Given
+        Long memberId = 1L;
+        Long meetingId = 2L;
+        MeetingTimeCreateRequest avoidTimeCreateRequest = mock(MeetingTimeCreateRequest.class);
+        TimeCreateRequest timeCreateRequest = mock(TimeCreateRequest.class);
+        Time time = mock(Time.class);
+        Event avoidEvent = mock(Event.class);
+        List<MeetingTimeCreateRequest> avoidTimeCreateRequests = List.of(avoidTimeCreateRequest);
+        Member member = mock(Member.class);
+        Meeting meeting = mock(Meeting.class);
+        MemberMeeting memberMeeting = mock(MemberMeeting.class);
+
+        // Mocking
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(meetingService.findMeeting(meetingId)).willReturn(meeting);
+        given(meetingService.findMemberMeeting(member, meeting)).willReturn(memberMeeting);
+        given(avoidTimeCreateRequest.toTimeCreateRequest()).willReturn(timeCreateRequest);
+        given(timeCreateRequest.toEntity()).willReturn(time);
+        given(eventService.saveAvoidTimeEvent(time)).willReturn(avoidEvent);
+
+        // When
+        assertDoesNotThrow(() -> meetingEventCreateService.saveMeetingAvoidTime(memberId, meetingId, avoidTimeCreateRequests));
+
+        // Then
+        verify(eventService).saveAvoidTimeEvent(time);
+        verify(meetingEventService).saveMeetingEvent(any(MeetingEvent.class));
+    }
+
+    @Test
+    void saveMeetingAvoidTime_InvalidMember() {
+        // Given
+        Long invalidMemberId = -1L;
+        Long meetingId = 2L;
+        List<MeetingTimeCreateRequest> avoidTimeCreateRequests = List.of(mock(MeetingTimeCreateRequest.class));
+
+        // Mocking
+        given(memberService.findMember(invalidMemberId)).willThrow(new IllegalArgumentException("멤버 ID가 없습니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> meetingEventCreateService.saveMeetingAvoidTime(invalidMemberId, meetingId, avoidTimeCreateRequests));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(),"멤버 ID가 없습니다.");
+        verify(memberService).findMember(invalidMemberId);
+    }
+
+    @Test
+    void saveMeetingAvoidTime_InvalidMeeting() {
+        // Given
+        Long memberId = 1L;
+        Long invalidMeetingId = -2L;
+        List<MeetingTimeCreateRequest> avoidTimeCreateRequests = List.of(mock(MeetingTimeCreateRequest.class));
+        Member member = mock(Member.class);
+
+        // Mocking
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(meetingService.findMeeting(invalidMeetingId)).willThrow(new IllegalArgumentException("모임 ID가 없습니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> meetingEventCreateService.saveMeetingAvoidTime(memberId, invalidMeetingId, avoidTimeCreateRequests));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(),"모임 ID가 없습니다.");
+        verify(memberService).findMember(memberId);
+        verify(meetingService).findMeeting(invalidMeetingId);
+    }
+}

--- a/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventServiceTest.java
@@ -35,8 +35,6 @@ class MeetingEventServiceTest {
     @Mock
     private MemberService memberService;
     @Mock
-    private TalkCalendarService talkCalendarService;
-    @Mock
     private MeetingService meetingService;
     @Mock
     private MeetingValidationService meetingValidationService;
@@ -49,9 +47,6 @@ class MeetingEventServiceTest {
 
     @InjectMocks
     private MeetingEventService meetingEventService;
-
-    @Captor
-    ArgumentCaptor<MeetingEvent> meetingEventArgumentCaptor;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventServiceTest.java
@@ -13,19 +13,14 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
 import org.cookieandkakao.babting.domain.food.service.FoodRepositoryService;
 import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
 import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateRequest;
 import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
-import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
-import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventRepository;
 import org.cookieandkakao.babting.domain.member.entity.Member;
 import org.cookieandkakao.babting.domain.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -41,8 +36,6 @@ class MeetingEventServiceTest {
     @Mock
     private MeetingEventCreateService meetingEventCreateService;
     @Mock
-    private MeetingEventRepository meetingEventRepository;
-    @Mock
     private FoodRepositoryService foodRepositoryService;
 
     @InjectMocks
@@ -51,36 +44,6 @@ class MeetingEventServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-    }
-
-    @Test
-    void saveMeetingEventTest() {
-        // Given
-        MeetingEvent meetingEvent = mock(MeetingEvent.class);
-
-        // When
-        meetingEventService.saveMeetingEvent(meetingEvent);
-
-        // Then
-        verify(meetingEventRepository).save(meetingEvent);
-    }
-
-    @Test
-    void saveMeetingEventTest_InvalidMeetingEvent() {
-        // Given
-        MeetingEvent meetingEvent = mock(MeetingEvent.class);
-
-        // Mocking
-        given(meetingEventRepository.save(meetingEvent)).willThrow(new IllegalArgumentException("존재하지 않는 MeetingEvent입니다."));
-
-        // When
-        Exception e = assertThrows(IllegalArgumentException.class,
-            () -> meetingEventService.saveMeetingEvent(meetingEvent));
-
-        // Then
-        assertEquals(e.getClass(), IllegalArgumentException.class);
-        assertEquals(e.getMessage(), "존재하지 않는 MeetingEvent입니다.");
-        verify(meetingEventRepository).save(meetingEvent);
     }
 
     @Test

--- a/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingEventServiceTest.java
@@ -1,0 +1,203 @@
+package org.cookieandkakao.babting.domain.meeting.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.cookieandkakao.babting.domain.calendar.service.TalkCalendarService;
+import org.cookieandkakao.babting.domain.food.service.FoodRepositoryService;
+import org.cookieandkakao.babting.domain.meeting.dto.request.ConfirmMeetingGetRequest;
+import org.cookieandkakao.babting.domain.meeting.dto.request.MeetingEventCreateRequest;
+import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
+import org.cookieandkakao.babting.domain.meeting.entity.MeetingEvent;
+import org.cookieandkakao.babting.domain.meeting.repository.MeetingEventRepository;
+import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.cookieandkakao.babting.domain.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MeetingEventServiceTest {
+
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private TalkCalendarService talkCalendarService;
+    @Mock
+    private MeetingService meetingService;
+    @Mock
+    private MeetingValidationService meetingValidationService;
+    @Mock
+    private MeetingEventCreateService meetingEventCreateService;
+    @Mock
+    private MeetingEventRepository meetingEventRepository;
+    @Mock
+    private FoodRepositoryService foodRepositoryService;
+
+    @InjectMocks
+    private MeetingEventService meetingEventService;
+
+    @Captor
+    ArgumentCaptor<MeetingEvent> meetingEventArgumentCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void saveMeetingEventTest() {
+        // Given
+        MeetingEvent meetingEvent = mock(MeetingEvent.class);
+
+        // When
+        meetingEventService.saveMeetingEvent(meetingEvent);
+
+        // Then
+        verify(meetingEventRepository).save(meetingEvent);
+    }
+
+    @Test
+    void saveMeetingEventTest_InvalidMeetingEvent() {
+        // Given
+        MeetingEvent meetingEvent = mock(MeetingEvent.class);
+
+        // Mocking
+        given(meetingEventRepository.save(meetingEvent)).willThrow(new IllegalArgumentException("존재하지 않는 MeetingEvent입니다."));
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> meetingEventService.saveMeetingEvent(meetingEvent));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "존재하지 않는 MeetingEvent입니다.");
+        verify(meetingEventRepository).save(meetingEvent);
+    }
+
+    @Test
+    void confirmMeetingTest() {
+        // Given
+        Long memberId = 1L;
+        Long meetingId = 2L;
+        Long foodId = 3L;
+
+        Member member = mock(Member.class);
+        Meeting meeting = mock(Meeting.class);
+        ConfirmMeetingGetRequest confirmMeetingGetRequest = mock(ConfirmMeetingGetRequest.class);
+
+        LocalDateTime confirmDateTime = LocalDateTime.now();
+
+        // Mocking
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(meetingService.findMeeting(meetingId)).willReturn(meeting);
+        given(confirmMeetingGetRequest.confirmFoodId()).willReturn(foodId);
+        given(confirmMeetingGetRequest.confirmDateTime()).willReturn(confirmDateTime);
+        given(meetingService.getMemberIdInMeetingId(meetingId)).willReturn(List.of(memberId));
+        doNothing().when(meeting).confirmDateTime(confirmDateTime);
+        given(meeting.getConfirmDateTime()).willReturn(confirmDateTime);
+        given(foodRepositoryService.findFoodById(foodId)).willReturn(null);
+        doNothing().when(meetingValidationService).validateHostPermission(member, meeting);
+        doNothing().when(meetingValidationService).validateMeetingConfirmation(meeting);
+
+        // When & Then
+        assertDoesNotThrow(() -> meetingEventService.confirmMeeting(memberId, meetingId, confirmMeetingGetRequest));
+        verify(meeting).confirmDateTime(confirmDateTime);
+        verify(meeting).confirmFood(any());
+        verify(meetingEventCreateService).addMeetingEvent(eq(memberId), any(MeetingEventCreateRequest.class));
+    }
+
+    @Test
+    void confirmMeeting_HostPermissionValidationFail() {
+        // Given
+        Long memberId = 1L;
+        Long meetingId = 2L;
+
+        Member member = mock(Member.class);
+        Meeting meeting = mock(Meeting.class);
+        ConfirmMeetingGetRequest confirmMeetingGetRequest = mock(ConfirmMeetingGetRequest.class);
+
+        // Mocking
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(meetingService.findMeeting(meetingId)).willReturn(meeting);
+        doThrow(new IllegalStateException("권한이 없습니다.")).when(meetingValidationService).validateHostPermission(member, meeting);
+
+        // When
+        Exception e = assertThrows(IllegalStateException.class,
+            () -> meetingEventService.confirmMeeting(memberId, meetingId, confirmMeetingGetRequest));
+
+        // Then
+        assertEquals(e.getClass(), IllegalStateException.class);
+        assertEquals(e.getMessage(), "권한이 없습니다.");
+        verify(meetingValidationService).validateHostPermission(member, meeting);
+    }
+
+    @Test
+    void confirmMeeting_ConfirmMeetingValidationFail() {
+        // Given
+        Long memberId = 1L;
+        Long meetingId = 2L;
+
+        Member member = mock(Member.class);
+        Meeting meeting = mock(Meeting.class);
+        ConfirmMeetingGetRequest confirmMeetingGetRequest = mock(ConfirmMeetingGetRequest.class);
+
+        // Mocking
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(meetingService.findMeeting(meetingId)).willReturn(meeting);
+        doThrow(new IllegalStateException("이미 모임 시간이 확정되었습니다.")).when(meetingValidationService).validateMeetingConfirmation(meeting);
+
+        // When
+        Exception e = assertThrows(IllegalStateException.class,
+            () -> meetingEventService.confirmMeeting(memberId, meetingId, confirmMeetingGetRequest));
+
+        // Then
+        assertEquals(e.getClass(), IllegalStateException.class);
+        assertEquals(e.getMessage(), "이미 모임 시간이 확정되었습니다.");
+        verify(meetingValidationService).validateHostPermission(member, meeting);
+        verify(meetingValidationService).validateMeetingConfirmation(meeting);
+    }
+
+    @Test
+    void confirmMeeting_NotFoundFood() {
+        // Given
+        Long memberId = 1L;
+        Long meetingId = 2L;
+        Long foodId = 3L;
+
+        Member member = mock(Member.class);
+        Meeting meeting = mock(Meeting.class);
+        ConfirmMeetingGetRequest confirmMeetingGetRequest = mock(ConfirmMeetingGetRequest.class);
+
+        // Mocking
+        given(memberService.findMember(memberId)).willReturn(member);
+        given(meetingService.findMeeting(meetingId)).willReturn(meeting);
+        given(confirmMeetingGetRequest.confirmFoodId()).willReturn(foodId);
+        doThrow(new IllegalArgumentException("음식을 찾을 수 없습니다.")).when(foodRepositoryService).findFoodById(foodId);
+
+        // When
+        Exception e = assertThrows(IllegalArgumentException.class,
+            () -> meetingEventService.confirmMeeting(memberId, meetingId, confirmMeetingGetRequest));
+
+        // Then
+        assertEquals(e.getClass(), IllegalArgumentException.class);
+        assertEquals(e.getMessage(), "음식을 찾을 수 없습니다.");
+        verify(meetingValidationService).validateHostPermission(member, meeting);
+        verify(meetingValidationService).validateMeetingConfirmation(meeting);
+        verify(foodRepositoryService).findFoodById(foodId);
+    }
+
+}

--- a/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingValidationServiceTest.java
+++ b/src/test/java/org/cookieandkakao/babting/domain/meeting/service/MeetingValidationServiceTest.java
@@ -1,0 +1,104 @@
+package org.cookieandkakao.babting.domain.meeting.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import org.cookieandkakao.babting.domain.meeting.entity.Meeting;
+import org.cookieandkakao.babting.domain.meeting.entity.MemberMeeting;
+import org.cookieandkakao.babting.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MeetingValidationServiceTest {
+
+    @InjectMocks
+    private MeetingValidationService meetingValidationService;
+
+    @Mock
+    private MeetingService meetingService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void validateHostPermissionTest() {
+        // Given
+        Long kakaoMemberId = 1L;
+        Member member = new Member(kakaoMemberId);
+        Meeting meeting = new Meeting(null, "Test Meeting", LocalDateTime.now().toLocalDate(),
+            LocalDateTime.now().toLocalDate(), 2, LocalDateTime.now().toLocalTime(),
+            LocalDateTime.now().toLocalTime());
+        MemberMeeting nonHostMemberMeeting = new MemberMeeting(member, meeting, true);
+
+        // Mocking
+        given(meetingService.findMemberMeeting(member, meeting)).willReturn(nonHostMemberMeeting);
+
+        // When & Then
+        assertDoesNotThrow(() -> meetingValidationService.validateHostPermission(member, meeting));
+
+    }
+
+    @Test
+    void validateHostPermissionTest_NotHost() {
+        // Given
+        Long kakaoMemberId = 1L;
+        Member member = new Member(kakaoMemberId);
+        Meeting meeting = new Meeting(null, "Test Meeting", LocalDateTime.now().toLocalDate(),
+            LocalDateTime.now().toLocalDate(), 2, LocalDateTime.now().toLocalTime(),
+            LocalDateTime.now().toLocalTime());
+        MemberMeeting nonHostMemberMeeting = new MemberMeeting(member, meeting, false);
+
+        // Mocking
+        given(meetingService.findMemberMeeting(member, meeting)).willReturn(nonHostMemberMeeting);
+
+        // When
+        Exception e = assertThrows(IllegalStateException.class,
+            () -> meetingValidationService.validateHostPermission(member, meeting));
+
+        // Then
+        assertEquals(e.getClass(), IllegalStateException.class);
+        assertEquals(e.getMessage(), "권한이 없습니다.");
+        verify(meetingService).findMemberMeeting(member, meeting);
+    }
+
+    @Test
+    void validateMeetingConfirmationTest() {
+        // Given
+        Meeting meeting = mock(Meeting.class);
+
+        // Mocking
+        given(meeting.getConfirmDateTime()).willReturn(null);
+
+        // When & Then
+        assertDoesNotThrow(() -> meetingValidationService.validateMeetingConfirmation(meeting));
+
+    }
+
+    @Test
+    void validateMeetingConfirmationTest_ExistingConfirmDateTime() {
+        LocalDateTime testTime = LocalDateTime.of(2024,11,6,12,30,35);
+        Meeting meeting = mock(Meeting.class);
+
+        // Mocking
+        given(meeting.getConfirmDateTime()).willReturn(testTime);
+
+        // When
+        Exception e = assertThrows(IllegalStateException.class,
+            () -> meetingValidationService.validateMeetingConfirmation(meeting));
+
+        // Then
+        assertEquals(e.getClass(), IllegalStateException.class);
+        assertEquals(e.getMessage(), "이미 모임 시간이 확정되었습니다.");
+        verify(meeting).getConfirmDateTime();
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
- 리뷰 반영
- MeetingEventService 분리
- 분리 후 생긴 Service에 대해 테스트 코드 작성
- 모임 참가 시 선호/비선호 음식 처리
- 모임 확정 시 모임의 확정 음식 추가
- .env 파일 만들어서 관리
- CORS 추가
- 모임별 개인 일정 조회 추가

## 리뷰어에게...
멘토님이 남겨주신 리뷰 최대한 반영했습니다. 
.env 파일은 .gitignore에 적혀 있어 깃에 업로드되지 않았습니다!
추가로 9주차 코드 +  이번에 반영한 내용으로 aws의 ec2와 rds를 사용해 docker-compose로 배포를 해두었습니다.
링크 : http://43.203.255.242/swagger-ui/index.html

## 관련 이슈

closes #

## 체크리스트

- [X] `reviewers` 설정
- [X] `label` 설정
